### PR TITLE
fix(t-brick-gen): proper conditional directory regex

### DIFF
--- a/tools/brick_generator/lib/src/reference_file.dart
+++ b/tools/brick_generator/lib/src/reference_file.dart
@@ -23,7 +23,7 @@ abstract class AltokeRegexp {
 
   /// Regexp to identify a conditional directory to be resolved within its path.
   static final conditionalDirRegexp = RegExp(
-    r'_cd(n?)___([^;\s]*)___([^;\s]*)',
+    r'_cd(n?)___([^;\s\\\/]*)___([^;\s\\\/]*)',
     dotAll: true,
   );
 


### PR DESCRIPTION
## Description

Use regex for conditional directories, so `/` and `\` are properly identified.