### PR TITLE
fix(b-altoke-app): ignore VSC extensions words in spellchecks

### DIFF
--- a/bricks/altoke_app/reference/.vscode/extensions.json
+++ b/bricks/altoke_app/reference/.vscode/extensions.json
@@ -1,3 +1,4 @@
+// cspell:ignore blaugold
 {
   "recommendations": [
     "dart-code.flutter",


### PR DESCRIPTION
## Description

Ignore words in VSCode extension in spellchecks.