### PR TITLE
fix(b-altoke-app): ignore Dart doc words in spellchecks

### DIFF
--- a/bricks/altoke_app/reference/.cspell/dart.allow.txt
+++ b/bricks/altoke_app/reference/.cspell/dart.allow.txt
@@ -1,5 +1,6 @@
 # Allowed words for Dart files
 coverde
+endtemplate
 lcov
 melos
 mocktail


### PR DESCRIPTION
## Description

Ignore Dart doc words in spellchecks.