### PR TITLE
fix(b-altoke-app): ignore snippet body for spell checks

### DIFF
--- a/bricks/altoke_app/reference/.vscode/dart.code-snippets
+++ b/bricks/altoke_app/reference/.vscode/dart.code-snippets
@@ -8,6 +8,7 @@
     "body": [
       "/// {@template ${1:package_name}.${2:template_name}}",
       "/// ${3}",
+      // cspell: disable-next-line
       "/// {@endtemplate}",
     ],
   },


### PR DESCRIPTION
## Description

Ignore snippet body in spell checks
