### PR TITLE
fix(b-altoke-common): proper `Optional` equality

### DIFF
--- a/bricks/altoke_common/reference/build.yaml
+++ b/bricks/altoke_common/reference/build.yaml
@@ -9,7 +9,6 @@ targets:
           - lib/src/types/_cf___use_dart_mappable___optional.dart
         options:
           generateMethods:
-            - equals
             - stringify
       #{{/use_dart_mappable}}#
       #{{#use_freezed}}#

--- a/bricks/altoke_common/reference/lib/src/types/_cf___use_dart_mappable___optional.dart
+++ b/bricks/altoke_common/reference/lib/src/types/_cf___use_dart_mappable___optional.dart
@@ -1,4 +1,5 @@
 import 'package:dart_mappable/dart_mappable.dart';
+import 'package:meta/meta.dart';
 
 part '_cf___use_dart_mappable___optional.mapper.dart';
 
@@ -21,19 +22,44 @@ sealed class DmOptional<T extends Object?> with DmOptionalMappable<T> {
 /// A representation of a present value.
 /// {@endtemplate}
 @MappableClass()
+@immutable
 class DmSome<T extends Object?> extends DmOptional<T> with DmSomeMappable<T> {
   /// {@macro common.some}
   const DmSome(this.value);
 
   /// The underlying value.
   final T value;
+
+  // HACK: Manual override required to avoid edge cases.
+  @override
+  bool operator ==(covariant DmOptional<T> other) {
+    if (other is! DmSome<T>) return false;
+    if (identical(this, other)) return true;
+    return other.value == value;
+  }
+
+  // HACK: Manual override required to avoid edge cases.
+  @override
+  int get hashCode => runtimeType.hashCode ^ value.hashCode;
 }
 
 /// {@template common.none}
 /// A representation of an absent value.
 /// {@endtemplate}
 @MappableClass()
+@immutable
 class DmNone<T extends Object?> extends DmOptional<T> with DmNoneMappable<T> {
   /// {@macro common.none}
   const DmNone();
+
+  // HACK: Manual override required to avoid edge cases.
+  @override
+  bool operator ==(covariant DmOptional<T> other) {
+    if (other is! DmNone<T>) return false;
+    return identical(this, other);
+  }
+
+  // HACK: Manual override required to avoid edge cases.
+  @override
+  int get hashCode => runtimeType.hashCode;
 }

--- a/bricks/altoke_common/reference/lib/src/types/_cf___use_dart_mappable___optional.mapper.dart
+++ b/bricks/altoke_common/reference/lib/src/types/_cf___use_dart_mappable___optional.mapper.dart
@@ -79,17 +79,6 @@ mixin DmSomeMappable<T extends Object?> {
   String toString() {
     return DmSomeMapper.ensureInitialized().stringifyValue(this as DmSome<T>);
   }
-
-  @override
-  bool operator ==(Object other) {
-    return DmSomeMapper.ensureInitialized()
-        .equalsValue(this as DmSome<T>, other);
-  }
-
-  @override
-  int get hashCode {
-    return DmSomeMapper.ensureInitialized().hashValue(this as DmSome<T>);
-  }
 }
 
 class DmNoneMapper extends ClassMapperBase<DmNone> {
@@ -125,16 +114,5 @@ mixin DmNoneMappable<T extends Object?> {
   @override
   String toString() {
     return DmNoneMapper.ensureInitialized().stringifyValue(this as DmNone<T>);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return DmNoneMapper.ensureInitialized()
-        .equalsValue(this as DmNone<T>, other);
-  }
-
-  @override
-  int get hashCode {
-    return DmNoneMapper.ensureInitialized().hashValue(this as DmNone<T>);
   }
 }

--- a/bricks/altoke_common/reference/lib/src/types/_cf___use_overrides___optional.dart
+++ b/bricks/altoke_common/reference/lib/src/types/_cf___use_overrides___optional.dart
@@ -32,7 +32,8 @@ class Some<T extends Object?> extends Optional<T> {
   String toString() => 'Some<$T>(value: $value)';
 
   @override
-  bool operator ==(covariant Some<T> other) {
+  bool operator ==(covariant Optional<T> other) {
+    if (other is! Some<T>) return false;
     if (identical(this, other)) return true;
     return other.value == value;
   }
@@ -53,7 +54,8 @@ class None<T extends Object?> extends Optional<T> {
   String toString() => 'None<$T>()';
 
   @override
-  bool operator ==(covariant None<T> other) {
+  bool operator ==(covariant Optional<T> other) {
+    if (other is! None<T>) return false;
     return identical(this, other);
   }
 

--- a/bricks/altoke_common/reference/pubspec.yaml
+++ b/bricks/altoke_common/reference/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   #*w 1v 2> w*#
   #{{#use_dart_mappable}}#
-  dart_mappable: ^4.2.2
+  dart_mappable: ^4.3.0
   #{{/use_dart_mappable}}#
   #{{#use_equatable}}#
   equatable: ^2.0.5
@@ -29,7 +29,7 @@ dev_dependencies:
   #*w 1v 2> w*#
   #{{/use_code_generation}}#
   #{{#use_dart_mappable}}#
-  dart_mappable_builder: ^4.2.3
+  dart_mappable_builder: ^4.3.0
   #{{/use_dart_mappable}}#
   #{{#use_freezed}}#
   freezed: ^2.5.7

--- a/bricks/altoke_common/reference/test/src/types/optional_test.dart
+++ b/bricks/altoke_common/reference/test/src/types/optional_test.dart
@@ -129,11 +129,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_dart_mappable}}*/
         const presentValue = DmOptional.some('some-value');
         const sameOptional = DmSome('some-value');
-        const differentOptional = DmSome('other-value');
+        const differentOptional1 = DmSome('other-value');
+        const differentOptional2 = DmSome<int>(42);
+        const differentOptional3 = DmNone<double>();
         expect(presentValue, sameOptional);
-        expect(presentValue, isNot(differentOptional));
+        expect(presentValue, isNot(differentOptional1));
+        expect(presentValue, isNot(differentOptional2));
+        expect(presentValue, isNot(differentOptional3));
         expect(presentValue.hashCode, sameOptional.hashCode);
-        expect(presentValue.hashCode, isNot(differentOptional.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_dart_mappable}}*/
         /*remove-start*/
       }
@@ -142,11 +148,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_equatable}}*/
         const presentValue = EOptional.some('some-value');
         const sameOptional = ESome('some-value');
-        const differentOptional = ESome('other-value');
+        const differentOptional1 = ESome('other-value');
+        const differentOptional2 = ESome<int>(42);
+        const differentOptional3 = ENone<double>();
         expect(presentValue, sameOptional);
-        expect(presentValue, isNot(differentOptional));
+        expect(presentValue, isNot(differentOptional1));
+        expect(presentValue, isNot(differentOptional2));
+        expect(presentValue, isNot(differentOptional3));
         expect(presentValue.hashCode, sameOptional.hashCode);
-        expect(presentValue.hashCode, isNot(differentOptional.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_equatable}}*/
         /*remove-start*/
       }
@@ -155,10 +167,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_freezed}}*/
         const presentValue = FOptional.some('some-value');
         const sameOptional = FSome('some-value');
-        const differentOptional = FSome('other-value');
+        const differentOptional1 = FSome('other-value');
+        const differentOptional2 = FSome<int>(42);
+        const differentOptional3 = FNone<double>();
         expect(presentValue, sameOptional);
-        expect(presentValue, isNot(differentOptional));
+        expect(presentValue, isNot(differentOptional1));
+        expect(presentValue, isNot(differentOptional2));
+        expect(presentValue, isNot(differentOptional3));
         expect(presentValue.hashCode, sameOptional.hashCode);
+        expect(presentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_freezed}}*/
         /*remove-start*/
       }
@@ -167,11 +186,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_overrides}}*/
         const presentValue = Optional.some('some-value');
         const sameOptional = Some('some-value');
-        const differentOptional = Some('other-value');
+        const differentOptional1 = Some('other-value');
+        const differentOptional2 = Some<int>(42);
+        const differentOptional3 = None<double>();
         expect(presentValue, sameOptional);
-        expect(presentValue, isNot(differentOptional));
+        expect(presentValue, isNot(differentOptional1));
+        expect(presentValue, isNot(differentOptional2));
+        expect(presentValue, isNot(differentOptional3));
         expect(presentValue.hashCode, sameOptional.hashCode);
-        expect(presentValue.hashCode, isNot(differentOptional.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(presentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_overrides}}*/
         /*remove-start*/
       }
@@ -197,19 +222,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_dart_mappable}}*/
         const absentValue = DmOptional<String>.none();
         const sameOptional = DmNone<String>();
-        /*remove-start*/
-        // const differentOptional = DmNone<int>();
-        /*remove-end*/
+        const differentOptional1 = DmNone<int>();
+        const differentOptional2 = DmNone<double>();
+        const differentOptional3 = DmSome<int>(42);
         expect(absentValue, sameOptional);
-        /*remove-start*/
-        // HACK: Equality should consider the type parameter.
-        // expect(absentValue, isNot(differentOptional));
-        /*remove-end*/
+        expect(absentValue, isNot(differentOptional1));
+        expect(absentValue, isNot(differentOptional2));
+        expect(absentValue, isNot(differentOptional3));
         expect(absentValue.hashCode, sameOptional.hashCode);
-        /*remove-start*/
-        // HACK: Hashes should consider the type parameter.
-        // expect(absentValue.hashCode, isNot(differentOptional.hashCode));
-        /*remove-end*/
+        expect(absentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_dart_mappable}}*/
         /*remove-start*/
       }
@@ -218,11 +241,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_equatable}}*/
         const absentValue = EOptional<String>.none();
         const sameOptional = ENone<String>();
-        const differentOptional = ENone<int>();
+        const differentOptional1 = ENone<int>();
+        const differentOptional2 = ENone<double>();
+        const differentOptional3 = ESome<int>(42);
         expect(absentValue, sameOptional);
-        expect(absentValue, isNot(differentOptional));
+        expect(absentValue, isNot(differentOptional1));
+        expect(absentValue, isNot(differentOptional2));
+        expect(absentValue, isNot(differentOptional3));
         expect(absentValue.hashCode, sameOptional.hashCode);
-        expect(absentValue.hashCode, isNot(differentOptional.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_equatable}}*/
         /*remove-start*/
       }
@@ -231,10 +260,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_freezed}}*/
         const absentValue = FOptional<String>.none();
         const sameOptional = FNone<String>();
-        const differentOptional = FNone<int>();
+        const differentOptional1 = FNone<int>();
+        const differentOptional2 = FNone<double>();
+        const differentOptional3 = FSome<int>(42);
         expect(absentValue, sameOptional);
-        expect(absentValue, isNot(differentOptional));
+        expect(absentValue, isNot(differentOptional1));
+        expect(absentValue, isNot(differentOptional2));
+        expect(absentValue, isNot(differentOptional3));
         expect(absentValue.hashCode, sameOptional.hashCode);
+        expect(absentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_freezed}}*/
         /*remove-start*/
       }
@@ -243,11 +279,17 @@ AND their hash codes are equal if they have the same values
         /*{{#use_overrides}}*/
         const absentValue = Optional<String>.none();
         const sameOptional = None<String>();
-        const differentOptional = None<int>();
+        const differentOptional1 = None<int>();
+        const differentOptional2 = None<double>();
+        const differentOptional3 = Some<int>(42);
         expect(absentValue, sameOptional);
-        expect(absentValue, isNot(differentOptional));
+        expect(absentValue, isNot(differentOptional1));
+        expect(absentValue, isNot(differentOptional2));
+        expect(absentValue, isNot(differentOptional3));
         expect(absentValue.hashCode, sameOptional.hashCode);
-        expect(absentValue.hashCode, isNot(differentOptional.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional1.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional2.hashCode));
+        expect(absentValue.hashCode, isNot(differentOptional3.hashCode));
         /*{{/use_overrides}}*/
         /*remove-start*/
       }


### PR DESCRIPTION
## Description

Use proper implementation for `Optional` equality (for the different variants.
