### PR TITLE
fix(b-altoke-common): proper `Optional` equality

### DIFF
--- a/bricks/altoke_common/reference/lib/src/types/_cf___use_dart_mappable___optional.dart
+++ b/bricks/altoke_common/reference/lib/src/types/_cf___use_dart_mappable___optional.dart
@@ -32,7 +32,7 @@ class DmSome<T extends Object?> extends DmOptional<T> with DmSomeMappable<T> {
 
   // HACK: Manual override required to avoid edge cases.
   @override
-  bool operator ==(covariant DmOptional<T> other) {
+  bool operator ==(Object other) {
     if (other is! DmSome<T>) return false;
     if (identical(this, other)) return true;
     return other.value == value;
@@ -54,7 +54,7 @@ class DmNone<T extends Object?> extends DmOptional<T> with DmNoneMappable<T> {
 
   // HACK: Manual override required to avoid edge cases.
   @override
-  bool operator ==(covariant DmOptional<T> other) {
+  bool operator ==(Object other) {
     if (other is! DmNone<T>) return false;
     return identical(this, other);
   }


### PR DESCRIPTION
## Description

Accept any instance for value equality.
