### PR TITLE
fix(t-brick-generator): remove actual brick template before generation

### DIFF
--- a/tools/brick_generator/lib/main.dart
+++ b/tools/brick_generator/lib/main.dart
@@ -54,8 +54,8 @@ Future<void> main(List<String> args) async {
   stdout.writeln('Generating brick template...');
 
   // Remove target directory.
-  if (brickTemplateDir.existsSync()) {
-    await Shell.removeDirectory(brickTemplateDir);
+  if (Dirs.brickTemplate.existsSync()) {
+    await Shell.removeDirectory(Dirs.brickTemplate);
   }
 
   // Remove untracked files from reference directory.


### PR DESCRIPTION
## Description

Remove actual brick template folder before running regeneration.
