### PR TITLE
chore: use quoted paths

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -152,7 +152,7 @@ scripts:
     run: >
       dart test -x ci-only --coverage=coverage -r expanded --test-randomize-ordering-seed random --color
       &&
-      format_coverage --lcov --in=./coverage/ --out=./coverage/lcov.info --report-on=lib -b MELOS_PACKAGE_PATH
+      format_coverage --lcov --in=./coverage/ --out=./coverage/lcov.info --report-on=lib -b 'MELOS_PACKAGE_PATH'
     packageFilters:
       flutter: false
       dirExists:
@@ -198,7 +198,7 @@ scripts:
   test.ci:
     description: Test all packages (CI)
     run: >
-      melos exec --order-dependents --fail-fast --no-flutter --dir-exists="test" --depends-on=test -- "dart test -x ci-only --coverage=coverage -r expanded --test-randomize-ordering-seed random && format_coverage --lcov --in=./coverage/ --out=./coverage/lcov.info --report-on=lib -b MELOS_PACKAGE_PATH"
+      melos exec --order-dependents --fail-fast --no-flutter --dir-exists="test" --depends-on=test -- "dart test -x ci-only --coverage=coverage -r expanded --test-randomize-ordering-seed random && format_coverage --lcov --in=./coverage/ --out=./coverage/lcov.info --report-on=lib -b 'MELOS_PACKAGE_PATH'"
       &&
       melos exec --order-dependents --fail-fast --flutter --dir-exists="test" --depends-on=flutter_test -- "flutter test -x ci-only --coverage -r expanded --test-randomize-ordering-seed random"
   coverage.merge:
@@ -206,7 +206,7 @@ scripts:
     run: >
       coverde rm MELOS_ROOT_PATH/coverage/filtered.lcov.info
       &&
-      melos exec -c 1 --file-exists=coverage/lcov.info -- "coverde filter --input ./coverage/lcov.info --output MELOS_ROOT_PATH/coverage/filtered.lcov.info --paths-parent MELOS_PACKAGE_PATH  --filters \.drift\.dart,\.freezed\.dart,\.g\.dart,\.gr\.dart,\.mapper\.dart"
+      melos exec -c 1 --file-exists=coverage/lcov.info -- "coverde filter --input ./coverage/lcov.info --output 'MELOS_ROOT_PATH/coverage/filtered.lcov.info' --paths-parent 'MELOS_PACKAGE_PATH'  --filters \.drift\.dart,\.freezed\.dart,\.g\.dart,\.gr\.dart,\.mapper\.dart"
   coverage.check:
     description: Check test coverage
     run: >


### PR DESCRIPTION
## Description

Use paths with quotes to avoid special-char-related issues.
