### PR TITLE
fix(b-altoke-app): drop legacy VSC extension

### DIFF
--- a/bricks/altoke_app/reference/altoke_app/.vscode/extensions.json
+++ b/bricks/altoke_app/reference/altoke_app/.vscode/extensions.json
@@ -1,9 +1,7 @@
-// cspell:ignore blaugold
 {
   "recommendations": [
     "dart-code.flutter",
     "google.arb-editor",
-    "blaugold.melos-code",
     "streetsidesoftware.code-spell-checker",
     "redhat.vscode-yaml",
   ],


### PR DESCRIPTION
## Description

Drop legacy unused VSCode extension for `melos.yaml` file linting and utils.
