### PR TITLE
test(b-gather-app): proper async initialization test for playground

### DIFF
--- a/bricks/altoke_app/reference/altoke_app/packages/app/test/app/state/async_initialization_pod_test.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/test/app/state/async_initialization_pod_test.dart
@@ -30,6 +30,11 @@ THEN the async initializer sequence should complete
             ref.onDispose(dir.delete);
             return dir;
           }),
+          asyncTemporaryDirectoryPod.overrideWith((ref) async {
+            final dir = await Directory.systemTemp.createTemp();
+            ref.onDispose(dir.delete);
+            return dir;
+          }),
           asyncDriftLocalDatabasePod.overrideWith(
             (ref) async => MockLocalDatabase(),
           ),


### PR DESCRIPTION
## Description

This pull request includes a small change to the `bricks/altoke_app/reference/altoke_app/packages/app/test/app/state/async_initialization_pod_test.dart` file. The change adds an override for the `asyncTemporaryDirectoryPod` to create a temporary directory and ensure it is deleted upon disposal.
