### PR TITLE
fix: disable Isar

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ Create a local database, **_al toque_** (_quickly_).
   Supported with one of the following alternatives:
     - [`drift` (SQLite)][pub_package_drift]
     - [`hive`][pub_package_hive]
-    - [`isar`][pub_package_isar]
     - [`sembast`][pub_package_sembast]
 
 - **Strict lint rules:**\
@@ -203,7 +202,6 @@ Create a package that provides general-purpose caches, **_al toque_** (_quickly_
 [pub_package_very_good_analysis]: https://pub.dev/packages/very_good_analysis
 [pub_package_drift]: https://pub.dev/packages/drift
 [pub_package_hive]: https://pub.dev/packages/hive
-[pub_package_isar]: https://pub.dev/packages/isar
 [pub_package_sembast]: https://pub.dev/packages/sembast
 <!-- BRICK LINKS -->
 

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/async_initialization_pod.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/async_initialization_pod.dart
@@ -14,7 +14,6 @@ part 'async_initialization_pod.g.dart';
     asyncTemporaryDirectory,
     asyncDriftLocalDatabase,
     asyncHiveInitialization,
-    asyncIsar,
   ],
 )
 // coverage:ignore-end
@@ -29,7 +28,6 @@ Future<void> asyncInitialization(Ref ref) async {
   await ref.watch(asyncTemporaryDirectoryPod.future);
   await ref.watch(asyncDriftLocalDatabasePod.future);
   await ref.watch(asyncHiveInitializationPod.future);
-  await ref.watch(asyncIsarPod.future);
   // coverage:ignore-end
   /*remove-end*/
 }

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/async_initialization_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/async_initialization_pod.g.dart
@@ -7,7 +7,7 @@ part of 'async_initialization_pod.dart';
 // **************************************************************************
 
 String _$asyncInitializationHash() =>
-    r'ff0fb24140ac54b388d1bd468b5b2aabc0610187';
+    r'cd515118506c4b8f845cb21f9bf3dddd709a4a86';
 
 /// See also [asyncInitialization].
 @ProviderFor(asyncInitialization)
@@ -23,7 +23,6 @@ final asyncInitializationPod = AutoDisposeFutureProvider<void>.internal(
     asyncTemporaryDirectoryPod,
     asyncDriftLocalDatabasePod,
     asyncHiveInitializationPod,
-    asyncIsarPod,
   },
   allTransitiveDependencies: <ProviderOrFamily>{
     asyncApplicationDocumentsDirectoryPod,
@@ -34,8 +33,6 @@ final asyncInitializationPod = AutoDisposeFutureProvider<void>.internal(
     ...?asyncDriftLocalDatabasePod.allTransitiveDependencies,
     asyncHiveInitializationPod,
     ...?asyncHiveInitializationPod.allTransitiveDependencies,
-    asyncIsarPod,
-    ...?asyncIsarPod.allTransitiveDependencies,
   },
 );
 

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/database_pod.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/database_pod.dart
@@ -6,8 +6,6 @@ import 'package:drift_local_database/drift_local_database.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
-import 'package:isar/isar.dart';
-import 'package:isar_local_database/isar_local_database.dart';
 import 'package:path/path.dart' as path;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -60,34 +58,11 @@ Future<void> asyncHiveInitialization(Ref ref) async {
   }
 }
 
-@Riverpod(dependencies: [asyncApplicationDocumentsDirectory])
-Future<Isar> asyncIsar(Ref ref) async {
-  const dbName = 'app_db';
-  final databasePath = ref.watch(
-    asyncApplicationDocumentsDirectoryPod.select(
-      (asyncDir) =>
-          path.joinAll([asyncDir.requireValue.path, 'isar_database', dbName]),
-    ),
-  );
-  final databaseDir = Directory(databasePath);
-  if (!databaseDir.existsSync()) {
-    await databaseDir.create(recursive: true);
-  }
-  final isar = await Isar.open(
-    name: dbName,
-    localDatabaseSchemas,
-    directory: databasePath,
-  );
-  ref.onDispose(isar.close);
-  return isar;
-}
-
 /*drop*/
 // coverage:ignore-start
 enum LocalDatabasePackage {
   drift('drift', 'Drift (SQLite)'),
-  hive('hive', 'Hive'),
-  isar('isar', 'Isar');
+  hive('hive', 'Hive');
 
   const LocalDatabasePackage(this.identifier, this.displayName);
 

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/database_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/database_pod.g.dart
@@ -57,25 +57,6 @@ final asyncHiveInitializationPod = AutoDisposeFutureProvider<void>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef AsyncHiveInitializationRef = AutoDisposeFutureProviderRef<void>;
-String _$asyncIsarHash() => r'ed4e3f359a22f34c3f7b283b034721c22fe59c9d';
-
-/// See also [asyncIsar].
-@ProviderFor(asyncIsar)
-final asyncIsarPod = AutoDisposeFutureProvider<Isar>.internal(
-  asyncIsar,
-  name: r'asyncIsarPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$asyncIsarHash,
-  dependencies: <ProviderOrFamily>[asyncApplicationDocumentsDirectoryPod],
-  allTransitiveDependencies: <ProviderOrFamily>{
-    asyncApplicationDocumentsDirectoryPod,
-    ...?asyncApplicationDocumentsDirectoryPod.allTransitiveDependencies,
-  },
-);
-
-@Deprecated('Will be removed in 3.0. Use Ref instead')
-// ignore: unused_element
-typedef AsyncIsarRef = AutoDisposeFutureProviderRef<Isar>;
 String _$selectedLocalDatabasePackageHash() =>
     r'05bcf0ffd220fe4a6144ea95453dc7b0d487104b';
 

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/data/local_tasks_dao_pod.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/data/local_tasks_dao_pod.dart
@@ -2,7 +2,6 @@ import 'package:altoke_app/external/external.dart';
 import 'package:drift_local_database/drift_local_database.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_local_database/hive_local_database.dart';
-import 'package:isar_local_database/isar_local_database.dart';
 import 'package:local_database/local_database.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -13,7 +12,6 @@ part 'local_tasks_dao_pod.g.dart';
     SelectedLocalDatabasePackage,
     asyncDriftLocalDatabase,
     asyncHiveInitialization,
-    asyncIsar,
   ],
 )
 LocalTasksDao localTasksDao(Ref ref) {
@@ -34,11 +32,5 @@ LocalTasksDao localTasksDao(Ref ref) {
         ),
       );
       return LocalTasksHiveDao();
-    case LocalDatabasePackage.isar:
-      return LocalTasksIsarDao(
-        database: ref.watch(
-          asyncIsarPod.select((asyncDatabase) => asyncDatabase.requireValue),
-        ),
-      );
   }
 }

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/data/local_tasks_dao_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/data/local_tasks_dao_pod.g.dart
@@ -6,7 +6,7 @@ part of 'local_tasks_dao_pod.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$localTasksDaoHash() => r'295609edb9a223bde540ffd8535f215ef3bda22d';
+String _$localTasksDaoHash() => r'696b6929be909b8add2f4668549b6ddf29165115';
 
 /// See also [localTasksDao].
 @ProviderFor(localTasksDao)
@@ -17,12 +17,11 @@ final localTasksDaoPod = AutoDisposeProvider<LocalTasksDao>.internal(
       const bool.fromEnvironment('dart.vm.product')
           ? null
           : _$localTasksDaoHash,
-  dependencies: <ProviderOrFamily>{
+  dependencies: <ProviderOrFamily>[
     selectedLocalDatabasePackagePod,
     asyncDriftLocalDatabasePod,
     asyncHiveInitializationPod,
-    asyncIsarPod,
-  },
+  ],
   allTransitiveDependencies: <ProviderOrFamily>{
     selectedLocalDatabasePackagePod,
     ...?selectedLocalDatabasePackagePod.allTransitiveDependencies,
@@ -30,8 +29,6 @@ final localTasksDaoPod = AutoDisposeProvider<LocalTasksDao>.internal(
     ...?asyncDriftLocalDatabasePod.allTransitiveDependencies,
     asyncHiveInitializationPod,
     ...?asyncHiveInitializationPod.allTransitiveDependencies,
-    asyncIsarPod,
-    ...?asyncIsarPod.allTransitiveDependencies,
   },
 );
 

--- a/bricks/altoke_app/reference/altoke_app/packages/app/pubspec.yaml
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/pubspec.yaml
@@ -37,14 +37,6 @@ dependencies:
   #remove-end#
   intl: ^0.19.0
   #x-remove-start#
-  isar:
-    hosted: https://pub.isar-community.dev/
-    version: 3.1.8
-  isar_flutter_libs:
-    hosted: https://pub.isar-community.dev/
-    version: 3.1.8
-  isar_local_database:
-    path: ../../../../../altoke_local_database/reference/local_database/isar_local_database/
   local_database:
     path: ../../../../../altoke_local_database/reference/local_database/local_database/
   path: ^1.9.1

--- a/bricks/altoke_app/reference/altoke_app/packages/app/test/app/state/async_initialization_pod_test.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/test/app/state/async_initialization_pod_test.dart
@@ -7,8 +7,8 @@ import 'package:drift_local_database/drift_local_database.dart';
 /*remove-end-x*/
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 /*x-remove-start*/
-import 'package:isar/isar.dart';
 
 import '../../helpers/helpers.dart';
 /*remove-end*/
@@ -39,7 +39,6 @@ THEN the async initializer sequence should complete
             (ref) async => MockLocalDatabase(),
           ),
           asyncHiveInitializationPod.overrideWith((ref) async {}),
-          asyncIsarPod.overrideWith((ref) async => MockIsar()),
         ],
         /*remove-end-x*/
       );
@@ -67,8 +66,6 @@ THEN the async initializer sequence should complete
         asyncHiveInitializationPod.future,
       );
       await expectLater(hiveInitialization, completes);
-      final isar = container.read(asyncIsarPod.future);
-      await expectLater(isar, completion(isA<Isar>()));
       /*remove-end*/
     },
   );

--- a/bricks/altoke_app/reference/altoke_app/packages/app/test/external/data/database_pod_test.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/test/external/data/database_pod_test.dart
@@ -1,46 +1,12 @@
-import 'dart:ffi';
 import 'dart:io';
 
 import 'package:altoke_app/external/external.dart';
 import 'package:drift_local_database/drift_local_database.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:isar/isar.dart';
 import 'package:path/path.dart' as path;
 
-extension on Abi {
-  String get localName {
-    switch (this) {
-      case Abi.macosArm64 || Abi.macosX64:
-        // cspell: disable-next-line
-        return 'libisar.dylib';
-      case Abi.linuxX64:
-        // cspell: disable-next-line
-        return 'libisar.so';
-      case Abi.windowsArm64 || Abi.windowsX64:
-        return 'isar.dll';
-      default:
-        throw UnsupportedError(
-          'Unsupported processor architecture "$this" for tests',
-        );
-    }
-  }
-}
-
 void main() {
-  setUpAll(() async {
-    // This step is a workaround to avoid issues affecting test suits.
-    // See: https://github.com/isar/isar/issues/1518
-    final isarLibDir = Directory.systemTemp.createTempSync('isar-test-lib-');
-    final abi = Abi.current();
-    await Isar.initializeIsarCore(
-      download: true,
-      libraries: {
-        abi: '${isarLibDir.path}${Platform.pathSeparator}${abi.localName}',
-      },
-    );
-  });
-
   test(
     '''
 
@@ -101,32 +67,6 @@ THEN it should complete without issues
       addTearDown(subscription.close);
       final asyncHiveInitialization = subscription.read();
       await expectLater(asyncHiveInitialization, completes);
-    },
-  );
-
-  test(
-    '''
-
-GIVEN an async pod for an Isar database
-WHEN it is invoked
-THEN it should return an Isar instance
-''',
-    () async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-      final fakeDir = await Directory.systemTemp.createTemp();
-      addTearDown(() => fakeDir.delete(recursive: true));
-      final container = ProviderContainer(
-        overrides: [
-          asyncApplicationDocumentsDirectoryPod.overrideWith(
-            (ref) async => fakeDir,
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      final subscription = container.listen(asyncIsarPod.future, (_, __) {});
-      addTearDown(subscription.close);
-      final asyncIsar = subscription.read();
-      await expectLater(asyncIsar, completion(isA<Isar>()));
     },
   );
 }

--- a/bricks/altoke_app/reference/altoke_app/packages/app/test/helpers/mocks/external.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/test/helpers/mocks/external.dart
@@ -1,8 +1,5 @@
 import 'package:drift_local_database/drift_local_database.dart';
-import 'package:isar/isar.dart';
 import 'package:mocktail/mocktail.dart';
-
-class MockIsar extends Mock implements Isar {}
 
 class MockLocalDatabase extends Mock implements LocalDatabase {}
 

--- a/bricks/altoke_app/reference/altoke_app/packages/app/test/tasks/data/local_tasks_dao_pod_test.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/test/tasks/data/local_tasks_dao_pod_test.dart
@@ -54,24 +54,4 @@ THEN a local tasks Hive DAO should be returned
       expect(dao, isA<LocalTasksDao>());
     },
   );
-
-  test(
-    '''
-
-GIVEN a local tasks DAO pod
-WHEN it is invoked
-THEN a local tasks Isar DAO should be returned
-''',
-    () async {
-      final isar = MockIsar();
-      final container = ProviderContainer(
-        overrides: [asyncIsarPod.overrideWith((ref) => isar)],
-      );
-      addTearDown(container.dispose);
-      container.read(selectedLocalDatabasePackagePod.notifier).value =
-          LocalDatabasePackage.isar;
-      final dao = container.read(localTasksDaoPod);
-      expect(dao, isA<LocalTasksDao>());
-    },
-  );
 }

--- a/bricks/altoke_local_database/brick/CHANGELOG.md
+++ b/bricks/altoke_local_database/brick/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - **FEAT**: Data persistence with `drift`.
 - **FEAT**: Data persistence with `hive`.
-- **FEAT**: Data persistence with `isar`.
 - **FEAT**: Data persistence with `sembast`.
 - **FEAT**: Strict lint rules with `very_good_analysis`.
 - **FEAT**: 100% test coverage.

--- a/bricks/altoke_local_database/brick/README.md
+++ b/bricks/altoke_local_database/brick/README.md
@@ -54,7 +54,6 @@ Create a local database, **_al toque_** (_quickly_).
   Supported with one of the following alternatives:
     - [`drift` (SQLite)][pub_package_drift]
     - [`hive`][pub_package_hive]
-    - [`isar`][pub_package_isar]
     - [`sembast`][pub_package_sembast]
 
 - **Strict lint rules:**\
@@ -68,9 +67,9 @@ Create a local database, **_al toque_** (_quickly_).
 <!-- VARIABLES -->
 ### Variables
 
-| Variable | Description | Default | Type |
-| -------- | ----------- | ------- | ---- |
-| `local_database_alternative` | The local database alternative. | drift | Enumeration |
+| Variable                     | Description                     | Default | Type        |
+| ---------------------------- | ------------------------------- | ------- | ----------- |
+| `local_database_alternative` | The local database alternative. | drift   | Enumeration |
 <!-- VARIABLES -->
 
 <!-- EDITABLE -->
@@ -78,7 +77,6 @@ Create a local database, **_al toque_** (_quickly_).
 [docs_dart_and_flutter_linter_rules_link]: https://dart.dev/tools/linter-rules
 [pub_package_drift]: https://pub.dev/packages/drift
 [pub_package_hive]: https://pub.dev/packages/hive
-[pub_package_isar]: https://pub.dev/packages/isar
 [pub_package_sembast]: https://pub.dev/packages/sembast
 [pub_package_very_good_analysis]: https://pub.dev/packages/very_good_analysis
 <!-- BRICK LINKS -->

--- a/bricks/altoke_local_database/brick/__brick__/{{#requirements_met}}local_database{{/requirements_met}}/{{#use_hive}}hive_local_database{{/use_hive}}/test/src/local_tasks_dao_test.dart
+++ b/bricks/altoke_local_database/brick/__brick__/{{#requirements_met}}local_database{{/requirements_met}}/{{#use_hive}}hive_local_database{{/use_hive}}/test/src/local_tasks_dao_test.dart
@@ -18,7 +18,7 @@ WHEN the constructor is called
 THEN an instance of $LocalTasksHiveDao is returned
 ''',
     () async {
-      final dbDir = Directory.systemTemp.createTempSync('isar-testing-');
+      final dbDir = Directory.systemTemp.createTempSync('hive-testing-');
       Hive.init(dbDir.path);
       final dao = LocalTasksHiveDao();
       expect(dao, isA<LocalTasksHiveDao>());
@@ -33,14 +33,14 @@ THEN an instance of $LocalTasksHiveDao is returned
     '''
 
 GIVEN a $LocalTasksHiveDao
-├─ THAT uses an Isar database''',
+├─ THAT uses an Hive database''',
     () {
       late Directory dbDir;
       late LocalTasksHiveDao dao;
       late hive.TasksBox tasksBox;
 
       setUp(() async {
-        dbDir = Directory.systemTemp.createTempSync('isar-testing-');
+        dbDir = Directory.systemTemp.createTempSync('hive-testing-');
         Hive.init(dbDir.path);
         dao = LocalTasksHiveDao();
         tasksBox = await dao.asyncTasksBox;

--- a/bricks/altoke_local_database/brick/__brick__/{{#requirements_met}}local_database{{/requirements_met}}/{{#use_isar}}isar_local_database{{/use_isar}}/analysis_options.yaml
+++ b/bricks/altoke_local_database/brick/__brick__/{{#requirements_met}}local_database{{/requirements_met}}/{{#use_isar}}isar_local_database{{/use_isar}}/analysis_options.yaml
@@ -1,6 +1,7 @@
 include: package:very_good_analysis/analysis_options.yaml
 analyzer:
   exclude:
+    - "**"
     - lib/**.g.dart
 linter:
   rules:

--- a/bricks/altoke_local_database/brick/brick.yaml
+++ b/bricks/altoke_local_database/brick/brick.yaml
@@ -11,7 +11,6 @@ vars:
     values:
       - drift
       - hive
-      - isar
       - sembast
     description: The local database alternative.
     default: drift

--- a/bricks/altoke_local_database/brick/hooks/post_gen.dart
+++ b/bricks/altoke_local_database/brick/hooks/post_gen.dart
@@ -96,8 +96,6 @@ Future<void> run(HookContext context) async {
 }
 
 extension on LocalDatabaseAlternative {
-  bool get shouldRunCodeGeneration => [
-    LocalDatabaseAlternative.drift,
-    LocalDatabaseAlternative.isar,
-  ].contains(this);
+  bool get shouldRunCodeGeneration =>
+      [LocalDatabaseAlternative.drift].contains(this);
 }

--- a/bricks/altoke_local_database/reference/local_database/hive_local_database/test/src/local_tasks_dao_test.dart
+++ b/bricks/altoke_local_database/reference/local_database/hive_local_database/test/src/local_tasks_dao_test.dart
@@ -18,7 +18,7 @@ WHEN the constructor is called
 THEN an instance of $LocalTasksHiveDao is returned
 ''',
     () async {
-      final dbDir = Directory.systemTemp.createTempSync('isar-testing-');
+      final dbDir = Directory.systemTemp.createTempSync('hive-testing-');
       Hive.init(dbDir.path);
       final dao = LocalTasksHiveDao();
       expect(dao, isA<LocalTasksHiveDao>());
@@ -33,14 +33,14 @@ THEN an instance of $LocalTasksHiveDao is returned
     '''
 
 GIVEN a $LocalTasksHiveDao
-├─ THAT uses an Isar database''',
+├─ THAT uses an Hive database''',
     () {
       late Directory dbDir;
       late LocalTasksHiveDao dao;
       late hive.TasksBox tasksBox;
 
       setUp(() async {
-        dbDir = Directory.systemTemp.createTempSync('isar-testing-');
+        dbDir = Directory.systemTemp.createTempSync('hive-testing-');
         Hive.init(dbDir.path);
         dao = LocalTasksHiveDao();
         tasksBox = await dao.asyncTasksBox;

--- a/bricks/altoke_local_database/reference/local_database/isar_local_database/analysis_options.yaml
+++ b/bricks/altoke_local_database/reference/local_database/isar_local_database/analysis_options.yaml
@@ -1,6 +1,7 @@
 include: package:very_good_analysis/analysis_options.yaml
 analyzer:
   exclude:
+    - "**"
     - lib/**.g.dart
 linter:
   rules:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -313,14 +313,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
-  dartx:
-    dependency: transitive
-    description:
-      name: dartx
-      sha256: "8b25435617027257d43e6508b5fe061012880ddfdaa75a71d607c3de2a13d244"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   drift:
     dependency: transitive
     description:
@@ -525,31 +517,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  isar:
-    dependency: transitive
-    description:
-      name: isar
-      sha256: e17a9555bc7f22ff26568b8c64d019b4ffa2dc6bd4cb1c8d9b269aefd32e53ad
-      url: "https://pub.isar-community.dev"
-    source: hosted
-    version: "3.1.8"
-  isar_flutter_libs:
-    dependency: transitive
-    description:
-      name: isar_flutter_libs
-      sha256: "78710781e658ce4bff59b3f38c5b2735e899e627f4e926e1221934e77b95231a"
-      url: "https://pub.isar-community.dev"
-    source: hosted
-    version: "3.1.8"
-  isar_generator:
-    dependency: transitive
-    description:
-      path: "packages/isar_generator"
-      ref: v3
-      resolved-ref: "96865ee1806d52e00d133caec2e1008543ca0a21"
-      url: "https://github.com/mdddj/isar"
-    source: git
-    version: "3.1.8"
   js:
     dependency: transitive
     description:
@@ -1067,14 +1034,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.8"
-  time:
-    dependency: transitive
-    description:
-      name: time
-      sha256: "370572cf5d1e58adcb3e354c47515da3f7469dac3a95b447117e728e7be6f461"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
   timing:
     dependency: transitive
     description:
@@ -1195,14 +1154,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
-  xxh3:
-    dependency: transitive
-    description:
-      name: xxh3
-      sha256: "399a0438f5d426785723c99da6b16e136f4953fb1e9db0bf270bd41dd4619916"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -252,6 +252,14 @@ melos:
         - brick.gen
         - brick.install
 
+    # Dependencies management
+    deps.outdated:
+      description: Check outdated dependencies
+      run: >
+        melos exec -- "dart pub outdated --no-dev-dependencies"
+        &&
+        melos exec -- "dart pub outdated --dev-dependencies"
+
 workspace:
   - bricks/altoke_app
   - bricks/altoke_app/brick/hooks
@@ -275,7 +283,7 @@ workspace:
   - bricks/altoke_local_database/e2e
   - bricks/altoke_local_database/reference/local_database/drift_local_database
   - bricks/altoke_local_database/reference/local_database/hive_local_database
-  - bricks/altoke_local_database/reference/local_database/isar_local_database
+  # - bricks/altoke_local_database/reference/local_database/isar_local_database
   - bricks/altoke_local_database/reference/local_database/local_database
   - bricks/altoke_local_database/reference/local_database/sembast_local_database
   - bricks/altoke_reactive_caches

--- a/tools/data_persistence_approach/lib/src/data_persistence_approach.dart
+++ b/tools/data_persistence_approach/lib/src/data_persistence_approach.dart
@@ -8,9 +8,6 @@ enum DataPersistenceApproach {
   /// Use `hive` for data persistence.
   hive('hive'),
 
-  /// Use `isar` for data persistence.
-  isar('isar'),
-
   /// Use `sembast` for data persistence.
   sembast('sembast');
 

--- a/tools/local_database_alternative/lib/src/local_database_alternative.dart
+++ b/tools/local_database_alternative/lib/src/local_database_alternative.dart
@@ -12,11 +12,6 @@ enum LocalDatabaseAlternative {
   /// NoSQL database.
   hive('hive'),
 
-  /// Isar.
-  ///
-  /// NoSQL database.
-  isar('isar'),
-
   /// Sembast.
   ///
   /// NoSQL database.


### PR DESCRIPTION
This pull request primarily focuses on removing the support for the Isar database from the project. The changes span across multiple files, including documentation, initialization pods, and tests.

Key changes include:

### Documentation Updates:
* Removed Isar from the list of supported databases in `README.md` and `CHANGELOG.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206) [[3]](diffhunk://#diff-7d7ecef94a8bf559cfb74ffb21c5fe0c44e1809192ab612efba98bdd76ea2bb7L5) [[4]](diffhunk://#diff-6bd19904dab815efdb4c0b76e4b7002163112018d33ffe158580ffd77740b7bbL57) [[5]](diffhunk://#diff-6bd19904dab815efdb4c0b76e4b7002163112018d33ffe158580ffd77740b7bbL81)

### Codebase Modifications:
* Removed Isar-related initialization code from `async_initialization_pod.dart` and `database_pod.dart`. [[1]](diffhunk://#diff-f508960dcc131b31f3f6013d8e15e6564148d31ed3cbfecc0d9884924b0213bdL17) [[2]](diffhunk://#diff-f508960dcc131b31f3f6013d8e15e6564148d31ed3cbfecc0d9884924b0213bdL32) [[3]](diffhunk://#diff-6eaa84356a5583c3ee244d89e9c20ff96c503d199dc51e43372d6195d47a88a9L9-L10) [[4]](diffhunk://#diff-6eaa84356a5583c3ee244d89e9c20ff96c503d199dc51e43372d6195d47a88a9L63-R65)

### Generated Code Updates:
* Updated generated files to reflect the removal of Isar dependencies (`async_initialization_pod.g.dart`, `database_pod.g.dart`, `local_tasks_dao_pod.g.dart`). [[1]](diffhunk://#diff-32fd9bc1fc84d52c67fe090fd2cd36530b24b795c3ddaf123c2d5b77f8e9d831L10-R10) [[2]](diffhunk://#diff-32fd9bc1fc84d52c67fe090fd2cd36530b24b795c3ddaf123c2d5b77f8e9d831L26) [[3]](diffhunk://#diff-32fd9bc1fc84d52c67fe090fd2cd36530b24b795c3ddaf123c2d5b77f8e9d831L37-L38) [[4]](diffhunk://#diff-95813aa5c07fe8d34ca0ea5b9068217fde2d2d585e0adbb2cb30952d059990d8L60-L78) [[5]](diffhunk://#diff-adec066c2be453e4ba700fd9dfb38f52fbd58a8dc5f8f9edc0ee7df9fada0181L9-R9) [[6]](diffhunk://#diff-adec066c2be453e4ba700fd9dfb38f52fbd58a8dc5f8f9edc0ee7df9fada0181L20-L34)

### Dependency Cleanup:
* Removed Isar dependencies from `pubspec.yaml`.

### Test Adjustments:
* Updated and removed tests related to Isar in various test files (`async_initialization_pod_test.dart`, `database_pod_test.dart`, `local_tasks_dao_pod_test.dart`, `external.dart`). [[1]](diffhunk://#diff-c7f3485c51a9c70b98f66b778da7f6b70330fca38399ecbae4efee0b09cc801fR10-L11) [[2]](diffhunk://#diff-c7f3485c51a9c70b98f66b778da7f6b70330fca38399ecbae4efee0b09cc801fL42) [[3]](diffhunk://#diff-c7f3485c51a9c70b98f66b778da7f6b70330fca38399ecbae4efee0b09cc801fL70-L71) [[4]](diffhunk://#diff-27a24e72c84741a65b80a6b40b7e6bf997ce1901b4055baa266ab332fb1b270fL1-L43) [[5]](diffhunk://#diff-27a24e72c84741a65b80a6b40b7e6bf997ce1901b4055baa266ab332fb1b270fL106-L131) [[6]](diffhunk://#diff-2b968fd50f353f5b270b7bdc2ae92a0bdfba22c33767b50e7f44e1b09a97c496L2-L6) [[7]](diffhunk://#diff-0fb2c4b42238b0b689b138383c30c87818470974a3ac858a981d4601df14c935L57-L76) [[8]](diffhunk://#diff-d581a81757bdb5eb891c9cbb5e496eec921e9b36a81b3ac34b3d6cdb5759064eL21-R21) [[9]](diffhunk://#diff-d581a81757bdb5eb891c9cbb5e496eec921e9b36a81b3ac34b3d6cdb5759064eL36-R43)