### PR TITLE
build: upgrade Flutter & Dart SDKs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Initialize melos
@@ -71,7 +71,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Install coverage

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Install coverage

--- a/.github/workflows/generate_templates.yaml
+++ b/.github/workflows/generate_templates.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Initialize melos
@@ -55,7 +55,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Initialize brick generator

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Initialize READMEs resolver
@@ -58,7 +58,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Initialize brick scopes
@@ -90,7 +90,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.0
+          flutter-version: 3.32.0
       - name: Install melos
         run: dart pub global activate melos 7.0.0-dev.8
       - name: Initialize READMEs resolver

--- a/bricks/altoke_app/brick/hooks/pubspec.yaml
+++ b/bricks/altoke_app/brick/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   collection: ^1.19.1

--- a/bricks/altoke_app/e2e/e2e/brick_e2e_test.dart
+++ b/bricks/altoke_app/e2e/e2e/brick_e2e_test.dart
@@ -80,7 +80,8 @@ Future<void> testSuccessfulGeneration({
 }) async {
   for (final generationCase in cases) {
     final (:routerPackage) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke App brick
 AND hooks enabled
@@ -151,7 +152,8 @@ Future<void> testGenerationWithoutHooks({
 }) async {
   for (final generationCase in cases) {
     final (:routerPackage) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke App brick
 AND hooks disabled

--- a/bricks/altoke_app/e2e/pubspec.yaml
+++ b/bricks/altoke_app/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   checked_yaml: ^2.0.3

--- a/bricks/altoke_app/pubspec.yaml
+++ b/bricks/altoke_app/pubspec.yaml
@@ -5,4 +5,4 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"

--- a/bricks/altoke_app/reference/altoke_app/packages/app/l10n.yaml
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/l10n.yaml
@@ -1,4 +1,3 @@
-synthetic-package: false
 arb-dir: lib/l10n/arb/
 output-dir: lib/l10n/gen/
 template-arb-file: app_en.arb

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/presentation/app.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/presentation/app.dart
@@ -20,12 +20,12 @@ class MyApp extends ConsumerWidget {
         router!;
         /*replace-start*/
         final child =
-        /*with*/
-        // return
-        /*replace-end*/ NavigatorUriListener(
-          router: router as Router<Object>,
-          child: FlavorBanner(child: InitializationWrapper(child: router)),
-        );
+            /*with*/
+            // return
+            /*replace-end*/ NavigatorUriListener(
+              router: router as Router<Object>,
+              child: FlavorBanner(child: InitializationWrapper(child: router)),
+            );
         /*x-remove-start*/
         return RouterPackageSwitcherWrapper(child: child);
         /*remove-end*/
@@ -66,8 +66,9 @@ class RouterPackageSwitcherWrapper extends ConsumerWidget {
             child: Center(
               child: TextButton.icon(
                 onPressed: () {
-                  final selectedRouterPackageIndex =
-                      ref.read(selectedRouterPackagePod).index;
+                  final selectedRouterPackageIndex = ref
+                      .read(selectedRouterPackagePod)
+                      .index;
                   final newRouterPackageIndex =
                       (selectedRouterPackageIndex + 1) %
                       RouterPackage.values.length;

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/async_initialization_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/async_initialization_pod.g.dart
@@ -14,10 +14,9 @@ String _$asyncInitializationHash() =>
 final asyncInitializationPod = AutoDisposeFutureProvider<void>.internal(
   asyncInitialization,
   name: r'asyncInitializationPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$asyncInitializationHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$asyncInitializationHash,
   dependencies: <ProviderOrFamily>{
     asyncApplicationDocumentsDirectoryPod,
     asyncTemporaryDirectoryPod,

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/provider_observer.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/app/state/provider_observer.dart
@@ -33,7 +33,8 @@ class LoggerProviderObserver extends ProviderObserver {
 ${DateTime.now()}
 Provider added
 Initial:  $value
-'''.trim();
+'''
+            .trim();
     log(message, name: provider.loggerName);
   }
 
@@ -49,7 +50,8 @@ Initial:  $value
 ${DateTime.now()}
 Provider failed
 $error
-'''.trim();
+'''
+            .trim();
     log(
       message,
       error: error,
@@ -71,7 +73,8 @@ ${DateTime.now()}
 Provider updated
 Previous: $previousValue
 New:      $newValue
-'''.trim();
+'''
+            .trim();
     log(message, name: provider.loggerName);
   }
 
@@ -84,7 +87,8 @@ New:      $newValue
         '''
 ${DateTime.now()}
 Provider disposed
-'''.trim();
+'''
+            .trim();
     log(message, name: provider.loggerName);
   }
 }

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/counter/state/counter_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/counter/state/counter_pod.g.dart
@@ -13,8 +13,9 @@ String _$counterHash() => r'a5b0ac670b07d2fccf70a50f9d81dabeb3608235';
 final counterPod = AutoDisposeNotifierProvider<Counter, int>.internal(
   Counter.new,
   name: r'counterPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$counterHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$counterHash,
   dependencies: const <ProviderOrFamily>[],
   allTransitiveDependencies: const <ProviderOrFamily>{},
 );

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/database_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/database_pod.g.dart
@@ -15,10 +15,9 @@ final asyncDriftLocalDatabasePod =
     AutoDisposeFutureProvider<LocalDatabase>.internal(
       asyncDriftLocalDatabase,
       name: r'asyncDriftLocalDatabasePod',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$asyncDriftLocalDatabaseHash,
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$asyncDriftLocalDatabaseHash,
       dependencies: <ProviderOrFamily>[
         asyncApplicationDocumentsDirectoryPod,
         asyncTemporaryDirectoryPod,
@@ -43,10 +42,9 @@ String _$asyncHiveInitializationHash() =>
 final asyncHiveInitializationPod = AutoDisposeFutureProvider<void>.internal(
   asyncHiveInitialization,
   name: r'asyncHiveInitializationPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$asyncHiveInitializationHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$asyncHiveInitializationHash,
   dependencies: <ProviderOrFamily>[asyncApplicationDocumentsDirectoryPod],
   allTransitiveDependencies: <ProviderOrFamily>{
     asyncApplicationDocumentsDirectoryPod,
@@ -62,19 +60,19 @@ String _$selectedLocalDatabasePackageHash() =>
 
 /// See also [SelectedLocalDatabasePackage].
 @ProviderFor(SelectedLocalDatabasePackage)
-final selectedLocalDatabasePackagePod = NotifierProvider<
-  SelectedLocalDatabasePackage,
-  LocalDatabasePackage
->.internal(
-  SelectedLocalDatabasePackage.new,
-  name: r'selectedLocalDatabasePackagePod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product')
+final selectedLocalDatabasePackagePod =
+    NotifierProvider<
+      SelectedLocalDatabasePackage,
+      LocalDatabasePackage
+    >.internal(
+      SelectedLocalDatabasePackage.new,
+      name: r'selectedLocalDatabasePackagePod',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
           ? null
           : _$selectedLocalDatabasePackageHash,
-  dependencies: const <ProviderOrFamily>[],
-  allTransitiveDependencies: const <ProviderOrFamily>{},
-);
+      dependencies: const <ProviderOrFamily>[],
+      allTransitiveDependencies: const <ProviderOrFamily>{},
+    );
 
 typedef _$SelectedLocalDatabasePackage = Notifier<LocalDatabasePackage>;
 // ignore_for_file: type=lint

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/directories_pods.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/external/data/directories_pods.g.dart
@@ -15,10 +15,9 @@ final asyncApplicationDocumentsDirectoryPod =
     AutoDisposeFutureProvider<Directory>.internal(
       asyncApplicationDocumentsDirectory,
       name: r'asyncApplicationDocumentsDirectoryPod',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$asyncApplicationDocumentsDirectoryHash,
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$asyncApplicationDocumentsDirectoryHash,
       dependencies: const <ProviderOrFamily>[],
       allTransitiveDependencies: const <ProviderOrFamily>{},
     );
@@ -36,10 +35,9 @@ final asyncTemporaryDirectoryPod =
     AutoDisposeFutureProvider<Directory>.internal(
       asyncTemporaryDirectory,
       name: r'asyncTemporaryDirectoryPod',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$asyncTemporaryDirectoryHash,
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$asyncTemporaryDirectoryHash,
       dependencies: const <ProviderOrFamily>[],
       allTransitiveDependencies: const <ProviderOrFamily>{},
     );

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/flavors/presentation/flavor_banner.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/flavors/presentation/flavor_banner.dart
@@ -9,15 +9,14 @@ class FlavorBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      foregroundPainter:
-          isProd
-              ? null
-              : BannerPainter(
-                message: flavor.label,
-                textDirection: TextDirection.ltr,
-                location: BannerLocation.topStart,
-                layoutDirection: TextDirection.ltr,
-              ),
+      foregroundPainter: isProd
+          ? null
+          : BannerPainter(
+              message: flavor.label,
+              textDirection: TextDirection.ltr,
+              location: BannerLocation.topStart,
+              layoutDirection: TextDirection.ltr,
+            ),
       child: child,
     );
   }

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/routing/router.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/routing/router.g.dart
@@ -87,10 +87,9 @@ String _$autoRouteConfigHash() => r'fc12ab8aa28b7aebffa96d2cda0e942424002616';
 final autoRouteConfigPod = AutoDisposeProvider<RouterConfig<UrlState>>.internal(
   autoRouteConfig,
   name: r'autoRouteConfigPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$autoRouteConfigHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$autoRouteConfigHash,
   dependencies: const <ProviderOrFamily>[],
   allTransitiveDependencies: const <ProviderOrFamily>{},
 );
@@ -106,10 +105,9 @@ final goRouterConfigPod =
     AutoDisposeProvider<RouterConfig<RouteMatchList>>.internal(
       goRouterConfig,
       name: r'goRouterConfigPod',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$goRouterConfigHash,
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$goRouterConfigHash,
       dependencies: const <ProviderOrFamily>[],
       allTransitiveDependencies: const <ProviderOrFamily>{},
     );
@@ -125,8 +123,9 @@ String _$routerConfigHash() => r'406e8fd9eb6e6af997c14e7855c667efe6554997';
 final routerConfigPod = AutoDisposeProvider<RouterConfig<Object>>.internal(
   routerConfig,
   name: r'routerConfigPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$routerConfigHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$routerConfigHash,
   dependencies: <ProviderOrFamily>[
     selectedRouterPackagePod,
     autoRouteConfigPod,
@@ -154,10 +153,9 @@ final selectedRouterPackagePod =
     NotifierProvider<SelectedRouterPackage, RouterPackage>.internal(
       SelectedRouterPackage.new,
       name: r'selectedRouterPackagePod',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$selectedRouterPackageHash,
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$selectedRouterPackageHash,
       dependencies: const <ProviderOrFamily>[],
       allTransitiveDependencies: const <ProviderOrFamily>{},
     );

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/data/local_tasks_dao_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/data/local_tasks_dao_pod.g.dart
@@ -13,10 +13,9 @@ String _$localTasksDaoHash() => r'696b6929be909b8add2f4668549b6ddf29165115';
 final localTasksDaoPod = AutoDisposeProvider<LocalTasksDao>.internal(
   localTasksDao,
   name: r'localTasksDaoPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$localTasksDaoHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$localTasksDaoHash,
   dependencies: <ProviderOrFamily>[
     selectedLocalDatabasePackagePod,
     asyncDriftLocalDatabasePod,

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/presentation/task_list_tile.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/presentation/task_list_tile.dart
@@ -47,23 +47,18 @@ class TaskListTile extends ConsumerWidget {
         ),
         title: Text(
           title,
-          style:
-              completed
-                  ? const TextStyle(decoration: TextDecoration.lineThrough)
-                  : null,
+          style: completed
+              ? const TextStyle(decoration: TextDecoration.lineThrough)
+              : null,
         ),
-        subtitle:
-            description == null
-                ? null
-                : Text(
-                  description,
-                  style:
-                      completed
-                          ? const TextStyle(
-                            decoration: TextDecoration.lineThrough,
-                          )
-                          : null,
-                ),
+        subtitle: description == null
+            ? null
+            : Text(
+                description,
+                style: completed
+                    ? const TextStyle(decoration: TextDecoration.lineThrough)
+                    : null,
+              ),
         value: completed,
         onChanged: (value) {
           if (value == null) return;

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/presentation/tasks_app_bar.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/presentation/tasks_app_bar.dart
@@ -37,8 +37,9 @@ class SwitchDbPackageAction extends ConsumerWidget {
     return IconButton(
       icon: const Icon(Icons.storage),
       onPressed: () {
-        final selectedLocalDatabasePackageIndex =
-            ref.read(selectedLocalDatabasePackagePod).index;
+        final selectedLocalDatabasePackageIndex = ref
+            .read(selectedLocalDatabasePackagePod)
+            .index;
         final newLocalDatabasePackageIndex =
             (selectedLocalDatabasePackageIndex + 1) %
             LocalDatabasePackage.values.length;

--- a/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/state/async_tasks_pod.g.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/lib/tasks/state/async_tasks_pod.g.dart
@@ -13,8 +13,9 @@ String _$asyncTasksHash() => r'befe0325d2483f47a0461b813fee3d06fc575009';
 final asyncTasksPod = AutoDisposeStreamProvider<Iterable<Task>>.internal(
   asyncTasks,
   name: r'asyncTasksPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$asyncTasksHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$asyncTasksHash,
   dependencies: <ProviderOrFamily>[localTasksDaoPod],
   allTransitiveDependencies: <ProviderOrFamily>{
     localTasksDaoPod,
@@ -34,10 +35,9 @@ final createTaskMutationPod =
     AutoDisposeAsyncNotifierProvider<CreateTaskMutation, NewTask?>.internal(
       CreateTaskMutation.new,
       name: r'createTaskMutationPod',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$createTaskMutationHash,
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$createTaskMutationHash,
       dependencies: <ProviderOrFamily>[localTasksDaoPod],
       allTransitiveDependencies: <ProviderOrFamily>{
         localTasksDaoPod,
@@ -51,22 +51,22 @@ String _$updateTaskMutationHash() =>
 
 /// See also [UpdateTaskMutation].
 @ProviderFor(UpdateTaskMutation)
-final updateTaskMutationPod = AutoDisposeAsyncNotifierProvider<
-  UpdateTaskMutation,
-  (int, PartialTask)?
->.internal(
-  UpdateTaskMutation.new,
-  name: r'updateTaskMutationPod',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product')
+final updateTaskMutationPod =
+    AutoDisposeAsyncNotifierProvider<
+      UpdateTaskMutation,
+      (int, PartialTask)?
+    >.internal(
+      UpdateTaskMutation.new,
+      name: r'updateTaskMutationPod',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
           ? null
           : _$updateTaskMutationHash,
-  dependencies: <ProviderOrFamily>[localTasksDaoPod],
-  allTransitiveDependencies: <ProviderOrFamily>{
-    localTasksDaoPod,
-    ...?localTasksDaoPod.allTransitiveDependencies,
-  },
-);
+      dependencies: <ProviderOrFamily>[localTasksDaoPod],
+      allTransitiveDependencies: <ProviderOrFamily>{
+        localTasksDaoPod,
+        ...?localTasksDaoPod.allTransitiveDependencies,
+      },
+    );
 
 typedef _$UpdateTaskMutation = AutoDisposeAsyncNotifier<(int, PartialTask)?>;
 String _$deleteTaskByIdMutationHash() =>
@@ -78,10 +78,9 @@ final deleteTaskByIdMutationPod =
     AutoDisposeAsyncNotifierProvider<DeleteTaskByIdMutation, int?>.internal(
       DeleteTaskByIdMutation.new,
       name: r'deleteTaskByIdMutationPod',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$deleteTaskByIdMutationHash,
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$deleteTaskByIdMutationHash,
       dependencies: <ProviderOrFamily>[localTasksDaoPod],
       allTransitiveDependencies: <ProviderOrFamily>{
         localTasksDaoPod,

--- a/bricks/altoke_app/reference/altoke_app/packages/app/pubspec.yaml
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/pubspec.yaml
@@ -71,4 +71,5 @@ dev_dependencies:
   very_good_analysis: ^7.0.0
 
 flutter:
+  generate: true
   uses-material-design: true

--- a/bricks/altoke_app/reference/altoke_app/packages/app/pubspec.yaml
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/pubspec.yaml
@@ -5,8 +5,8 @@ version: 1.0.0+1
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
-  flutter: ">=3.29.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0 <4.0.0"
 
 dependencies:
   #remove-start#
@@ -35,7 +35,7 @@ dependencies:
   hive_local_database:
     path: ../../../../../altoke_local_database/reference/local_database/hive_local_database/
   #remove-end#
-  intl: ^0.19.0
+  intl: ^0.20.2
   #x-remove-start#
   local_database:
     path: ../../../../../altoke_local_database/reference/local_database/local_database/

--- a/bricks/altoke_app/reference/altoke_app/packages/app/test/app/presentation/app_test.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/test/app/presentation/app_test.dart
@@ -29,9 +29,8 @@ THEN the flavor banner should be displayed
             path: '/',
             page: PageInfo(
               'FakeRoute',
-              builder:
-                  (data) =>
-                      const Scaffold(body: Center(child: Text('Fake Screen'))),
+              builder: (data) =>
+                  const Scaffold(body: Center(child: Text('Fake Screen'))),
             ),
           ),
         ],
@@ -70,9 +69,8 @@ THEN the initialized router content should be shown
             path: '/',
             page: PageInfo(
               'FakeRoute',
-              builder:
-                  (data) =>
-                      const Scaffold(body: Center(child: Text('Fake Screen'))),
+              builder: (data) =>
+                  const Scaffold(body: Center(child: Text('Fake Screen'))),
             ),
           ),
         ],
@@ -112,9 +110,8 @@ THEN the errored initialization screen should be shown
             path: '/',
             page: PageInfo(
               'FakeRoute',
-              builder:
-                  (data) =>
-                      const Scaffold(body: Center(child: Text('Fake Screen'))),
+              builder: (data) =>
+                  const Scaffold(body: Center(child: Text('Fake Screen'))),
             ),
           ),
         ],
@@ -164,9 +161,8 @@ THEN the flavor banner should be displayed
           GoRoute(
             path: '/',
             name: 'FakeRoute',
-            builder:
-                (context, state) =>
-                    const Scaffold(body: Center(child: Text('Fake Screen'))),
+            builder: (context, state) =>
+                const Scaffold(body: Center(child: Text('Fake Screen'))),
           ),
         ],
       );
@@ -201,9 +197,8 @@ THEN the initialized router content should be shown
           GoRoute(
             path: '/',
             name: 'FakeRoute',
-            builder:
-                (context, state) =>
-                    const Scaffold(body: Center(child: Text('Fake Screen'))),
+            builder: (context, state) =>
+                const Scaffold(body: Center(child: Text('Fake Screen'))),
           ),
         ],
       );
@@ -239,9 +234,8 @@ THEN the errored initialization screen should be shown
           GoRoute(
             path: '/',
             name: 'FakeRoute',
-            builder:
-                (context, state) =>
-                    const Scaffold(body: Center(child: Text('Fake Screen'))),
+            builder: (context, state) =>
+                const Scaffold(body: Center(child: Text('Fake Screen'))),
           ),
         ],
       );

--- a/bricks/altoke_app/reference/altoke_app/packages/app/test/helpers/tester/pump.dart
+++ b/bricks/altoke_app/reference/altoke_app/packages/app/test/helpers/tester/pump.dart
@@ -73,17 +73,14 @@ extension AppTester on WidgetTester {
       NestedScrollView(
         physics: physics,
         controller: scrollController,
-        headerSliverBuilder:
-            (context, innerBoxIsScrolled) => [
-              SliverOverlapAbsorber(
-                handle: NestedScrollView.sliverOverlapAbsorberHandleFor(
-                  context,
-                ),
-                sliver: SliverToBoxAdapter(
-                  child: SizedBox(height: fakeHeaderHeight),
-                ),
-              ),
-            ],
+        headerSliverBuilder: (context, innerBoxIsScrolled) => [
+          SliverOverlapAbsorber(
+            handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+            sliver: SliverToBoxAdapter(
+              child: SizedBox(height: fakeHeaderHeight),
+            ),
+          ),
+        ],
         body: body,
       ),
       overrides: overrides,

--- a/bricks/altoke_app/reference/altoke_app/pubspec.yaml
+++ b/bricks/altoke_app/reference/altoke_app/pubspec.yaml
@@ -7,8 +7,8 @@ resolution: workspace
 #w 2v w#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
-  flutter: ">=3.29.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0 <4.0.0"
 
 dev_dependencies:
   melos: ^7.0.0-dev.8
@@ -18,8 +18,8 @@ melos:
   command:
     bootstrap:
       environment:
-        sdk: ">=3.7.0 <4.0.0"
-        flutter: ">=3.29.0 <4.0.0"
+        sdk: ">=3.8.0 <4.0.0"
+        flutter: ">=3.32.0 <4.0.0"
       dependencies:
         meta: ^1.16.0
       dev_dependencies:

--- a/bricks/altoke_common/brick/hooks/pubspec.yaml
+++ b/bricks/altoke_common/brick/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/bricks/altoke_common/e2e/e2e/brick_e2e_test.dart
+++ b/bricks/altoke_common/e2e/e2e/brick_e2e_test.dart
@@ -46,7 +46,8 @@ typedef GenerationCase = ({ValueEqualityApproach valueEqualityApproach});
 Future<void> testGeneration({required Set<GenerationCase> cases}) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Common brick
 AND hooks enabled
@@ -112,7 +113,8 @@ Future<void> testGenerationWithoutHooks({
 }) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Common brick
 AND hooks disabled

--- a/bricks/altoke_common/e2e/pubspec.yaml
+++ b/bricks/altoke_common/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   checked_yaml: ^2.0.3

--- a/bricks/altoke_common/pubspec.yaml
+++ b/bricks/altoke_common/pubspec.yaml
@@ -5,4 +5,4 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"

--- a/bricks/altoke_common/reference/common/lib/src/types/optional.mapper.dart
+++ b/bricks/altoke_common/reference/common/lib/src/types/optional.mapper.dart
@@ -23,7 +23,8 @@ class DmOptionalMapper extends ClassMapperBase<DmOptional> {
   @override
   final String id = 'DmOptional';
   @override
-  Function get typeFactory => <T extends Object?>(f) => f<DmOptional<T>>();
+  Function get typeFactory =>
+      <T extends Object?>(f) => f<DmOptional<T>>();
 
   @override
   final MappableFields<DmOptional> fields = const {};
@@ -54,7 +55,8 @@ class DmSomeMapper extends ClassMapperBase<DmSome> {
   @override
   final String id = 'DmSome';
   @override
-  Function get typeFactory => <T extends Object?>(f) => f<DmSome<T>>();
+  Function get typeFactory =>
+      <T extends Object?>(f) => f<DmSome<T>>();
 
   static Object? _$value(DmSome v) => v.value;
   static dynamic _arg$value<T extends Object?>(f) => f<T>();
@@ -98,7 +100,8 @@ class DmNoneMapper extends ClassMapperBase<DmNone> {
   @override
   final String id = 'DmNone';
   @override
-  Function get typeFactory => <T extends Object?>(f) => f<DmNone<T>>();
+  Function get typeFactory =>
+      <T extends Object?>(f) => f<DmNone<T>>();
 
   @override
   final MappableFields<DmNone> fields = const {};

--- a/bricks/altoke_common/reference/common/pubspec.yaml
+++ b/bricks/altoke_common/reference/common/pubspec.yaml
@@ -7,7 +7,7 @@ resolution: workspace
 #remove-end#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   #{{#use_dart_mappable}}x#

--- a/bricks/altoke_dart_package/brick/hooks/pubspec.yaml
+++ b/bricks/altoke_dart_package/brick/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/bricks/altoke_dart_package/e2e/pubspec.yaml
+++ b/bricks/altoke_dart_package/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   mason: ^0.1.1

--- a/bricks/altoke_dart_package/pubspec.yaml
+++ b/bricks/altoke_dart_package/pubspec.yaml
@@ -5,4 +5,4 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"

--- a/bricks/altoke_dart_package/reference/altoke_dart_package/pubspec.yaml
+++ b/bricks/altoke_dart_package/reference/altoke_dart_package/pubspec.yaml
@@ -7,7 +7,7 @@ resolution: workspace
 #remove-end#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   #{{#use_code_generation}}x#

--- a/bricks/altoke_entities/brick/hooks/pubspec.yaml
+++ b/bricks/altoke_entities/brick/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/bricks/altoke_entities/e2e/e2e/brick_e2e_test.dart
+++ b/bricks/altoke_entities/e2e/e2e/brick_e2e_test.dart
@@ -57,7 +57,8 @@ Future<void> testSuccessfulGeneration({
 }) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Entities brick
 AND hooks enabled
@@ -134,7 +135,8 @@ Future<void> testGenerationWithoutCommonPackage({
 }) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Entities brick
 AND hooks enabled
@@ -170,7 +172,8 @@ Future<void> testGenerationWithoutHooks({
 }) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Entities brick
 AND hooks disabled

--- a/bricks/altoke_entities/e2e/pubspec.yaml
+++ b/bricks/altoke_entities/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   checked_yaml: ^2.0.3

--- a/bricks/altoke_entities/pubspec.yaml
+++ b/bricks/altoke_entities/pubspec.yaml
@@ -5,4 +5,4 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"

--- a/bricks/altoke_entities/reference/altoke_entities/pubspec.yaml
+++ b/bricks/altoke_entities/reference/altoke_entities/pubspec.yaml
@@ -7,7 +7,7 @@ resolution: workspace
 #remove-end#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   altoke_common:

--- a/bricks/altoke_entity/brick/hooks/pubspec.yaml
+++ b/bricks/altoke_entity/brick/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/bricks/altoke_entity/e2e/e2e/brick_e2e_test.dart
+++ b/bricks/altoke_entity/e2e/e2e/brick_e2e_test.dart
@@ -57,7 +57,8 @@ Future<void> testSuccessfulGeneration({
 }) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Entity brick
 AND hooks enabled
@@ -134,7 +135,8 @@ Future<void> testGenerationWithoutCommonPackage({
 }) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Entity brick
 AND hooks enabled
@@ -172,7 +174,8 @@ Future<void> testGenerationWithoutHooks({
 }) async {
   for (final generationCase in cases) {
     final (:valueEqualityApproach) = generationCase;
-    final composedDescription = '''
+    final composedDescription =
+        '''
 
 GIVEN the Altoke Entity brick
 AND hooks disabled

--- a/bricks/altoke_entity/e2e/pubspec.yaml
+++ b/bricks/altoke_entity/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   checked_yaml: ^2.0.3

--- a/bricks/altoke_entity/pubspec.yaml
+++ b/bricks/altoke_entity/pubspec.yaml
@@ -5,4 +5,4 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"

--- a/bricks/altoke_entity/reference/altoke_entity/lib/src/altoke_entity.mapper.dart
+++ b/bricks/altoke_entity/reference/altoke_entity/lib/src/altoke_entity.mapper.dart
@@ -301,10 +301,11 @@ mixin DmPartialAltokeEntityMappable {
     DmPartialAltokeEntity,
     DmPartialAltokeEntity
   >
-  get copyWith => _DmPartialAltokeEntityCopyWithImpl<
-    DmPartialAltokeEntity,
-    DmPartialAltokeEntity
-  >(this as DmPartialAltokeEntity, $identity, $identity);
+  get copyWith =>
+      _DmPartialAltokeEntityCopyWithImpl<
+        DmPartialAltokeEntity,
+        DmPartialAltokeEntity
+      >(this as DmPartialAltokeEntity, $identity, $identity);
   @override
   String toString() {
     return DmPartialAltokeEntityMapper.ensureInitialized().stringifyValue(

--- a/bricks/altoke_entity/reference/altoke_entity/pubspec.yaml
+++ b/bricks/altoke_entity/reference/altoke_entity/pubspec.yaml
@@ -7,7 +7,7 @@ resolution: workspace
 #remove-end#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   altoke_common:

--- a/bricks/altoke_local_database/brick/hooks/pubspec.yaml
+++ b/bricks/altoke_local_database/brick/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   local_database_alternative:

--- a/bricks/altoke_local_database/e2e/pubspec.yaml
+++ b/bricks/altoke_local_database/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   checked_yaml: ^2.0.3

--- a/bricks/altoke_local_database/pubspec.yaml
+++ b/bricks/altoke_local_database/pubspec.yaml
@@ -5,4 +5,4 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"

--- a/bricks/altoke_local_database/reference/local_database/drift_local_database/lib/src/tasks.drift.dart
+++ b/bricks/altoke_local_database/reference/local_database/drift_local_database/lib/src/tasks.drift.dart
@@ -142,12 +142,12 @@ class $TasksTableManager
         i0.TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => i3.$TasksFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () => i3.$TasksOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () => i3.$TasksAnnotationComposer($db: db, $table: table),
+          createFilteringComposer: () =>
+              i3.$TasksFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              i3.$TasksOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              i3.$TasksAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 i0.Value<int> id = const i0.Value.absent(),
@@ -176,16 +176,9 @@ class $TasksTableManager
                 completed: completed,
                 description: description,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          i0.BaseReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
           prefetchHooksCallback: null,
         ),
       );
@@ -320,27 +313,24 @@ class Tasks extends i0.Table with i0.TableInfo<Tasks, i1.Task> {
   i1.Task map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return i1.Task(
-      id:
-          attachedDatabase.typeMapping.read(
-            i0.DriftSqlType.int,
-            data['${effectivePrefix}id'],
-          )!,
-      title:
-          attachedDatabase.typeMapping.read(
-            i0.DriftSqlType.string,
-            data['${effectivePrefix}title'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
       priority: i3.Tasks.$converterpriority.fromSql(
         attachedDatabase.typeMapping.read(
           i0.DriftSqlType.string,
           data['${effectivePrefix}priority'],
         )!,
       ),
-      completed:
-          attachedDatabase.typeMapping.read(
-            i0.DriftSqlType.bool,
-            data['${effectivePrefix}completed'],
-          )!,
+      completed: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.bool,
+        data['${effectivePrefix}completed'],
+      )!,
       description: attachedDatabase.typeMapping.read(
         i0.DriftSqlType.string,
         data['${effectivePrefix}description'],

--- a/bricks/altoke_local_database/reference/local_database/drift_local_database/pubspec.yaml
+++ b/bricks/altoke_local_database/reference/local_database/drift_local_database/pubspec.yaml
@@ -8,7 +8,7 @@ resolution: workspace
 #w 2v w#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   #w 1v 2> w#

--- a/bricks/altoke_local_database/reference/local_database/drift_local_database/test/src/local_tasks_dao_test.dart
+++ b/bricks/altoke_local_database/reference/local_database/drift_local_database/test/src/local_tasks_dao_test.dart
@@ -69,12 +69,14 @@ THEN a task record is registered
               table.title.equals(newTask.title) &
               table.priority.equalsValue(newTask.priority) &
               table.description.isNull();
-          final existingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final existingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(existingMatchingTasksCount, isZero);
           await dao.createOne(newTask);
-          final resultingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final resultingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(resultingMatchingTasksCount, existingMatchingTasksCount + 1);
         },
       );
@@ -89,15 +91,17 @@ AND no task record is registered
 ''',
         () async {
           const newTask = NewTask(title: '', priority: TaskPriority.high);
-          final existingMatchingTasksCount =
-              await tasksTable.count().getSingle();
+          final existingMatchingTasksCount = await tasksTable
+              .count()
+              .getSingle();
           expect(existingMatchingTasksCount, isZero);
           expect(
             () async => dao.createOne(newTask),
             throwsA(isA<CreateTaskFailureInvalidData>()),
           );
-          final resultingMatchingTasksCount =
-              await tasksTable.count().getSingle();
+          final resultingMatchingTasksCount = await tasksTable
+              .count()
+              .getSingle();
           expect(resultingMatchingTasksCount, isZero);
         },
       );
@@ -254,8 +258,9 @@ THEN a task record is updated
                 tasksTable.description.equals(newDescription);
           }
 
-          final existingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final existingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(existingMatchingTasksCount, isZero);
           await dao.updateOneById(
             taskId: task.id,
@@ -266,8 +271,9 @@ THEN a task record is updated
               description: Some(newDescription),
             ),
           );
-          final resultingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final resultingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(resultingMatchingTasksCount, existingMatchingTasksCount + 1);
         },
       );
@@ -298,8 +304,9 @@ AND no task record is updated
                 tasksTable.description.equals(newDescription);
           }
 
-          final existingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final existingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(existingMatchingTasksCount, isZero);
           expect(
             () async => dao.updateOneById(
@@ -313,8 +320,9 @@ AND no task record is updated
             ),
             throwsA(isA<UpdateTaskFailureNotFound>()),
           );
-          final resultingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final resultingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(resultingMatchingTasksCount, isZero);
         },
       );
@@ -352,8 +360,9 @@ AND no task record is updated
                 tasksTable.description.equals(newDescription);
           }
 
-          final existingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final existingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(existingMatchingTasksCount, isZero);
           expect(
             () async => dao.updateOneById(
@@ -367,8 +376,9 @@ AND no task record is updated
             ),
             throwsA(isA<UpdateTaskFailureInvalidData>()),
           );
-          final resultingMatchingTasksCount =
-              await tasksTable.count(where: filter).getSingle();
+          final resultingMatchingTasksCount = await tasksTable
+              .count(where: filter)
+              .getSingle();
           expect(resultingMatchingTasksCount, isZero);
         },
       );
@@ -392,16 +402,14 @@ AND the deleted task is returned
             description: 'description',
           );
           await tasksTable.insertOne(task.toDrift());
-          final initialMatchingTasksCount =
-              await tasksTable
-                  .count(where: (table) => table.id.equals(taskId))
-                  .getSingle();
+          final initialMatchingTasksCount = await tasksTable
+              .count(where: (table) => table.id.equals(taskId))
+              .getSingle();
           expect(initialMatchingTasksCount, 1);
           await dao.deleteOneById(taskId);
-          final resultingMatchingTasksCount =
-              await tasksTable
-                  .count(where: (table) => table.id.equals(taskId))
-                  .getSingle();
+          final resultingMatchingTasksCount = await tasksTable
+              .count(where: (table) => table.id.equals(taskId))
+              .getSingle();
           expect(resultingMatchingTasksCount, isZero);
         },
       );

--- a/bricks/altoke_local_database/reference/local_database/hive_local_database/lib/src/local_tasks_dao.dart
+++ b/bricks/altoke_local_database/reference/local_database/hive_local_database/lib/src/local_tasks_dao.dart
@@ -39,8 +39,9 @@ class LocalTasksHiveDao implements LocalTasksDao {
     final id = await tasksBox.add({
       hive.Task.titleJsonKey: title,
       hive.Task.priorityJsonKey: priority.identifier,
-      hive.Task.descriptionJsonKey:
-          ((description ?? '').trim().isEmpty) ? null : description?.trim(),
+      hive.Task.descriptionJsonKey: ((description ?? '').trim().isEmpty)
+          ? null
+          : description?.trim(),
       hive.Task.completedJsonKey: false,
     });
     return newTask.toTaskWithId(id);
@@ -99,8 +100,9 @@ class LocalTasksHiveDao implements LocalTasksDao {
       rawTask[hive.Task.completedJsonKey] = completed;
     }
     if (description case Some(value: final description)) {
-      rawTask[hive.Task.descriptionJsonKey] =
-          (description ?? '').trim().isEmpty ? null : description?.trim();
+      rawTask[hive.Task.descriptionJsonKey] = (description ?? '').trim().isEmpty
+          ? null
+          : description?.trim();
     }
     await tasksBox.put(taskId, rawTask);
   }
@@ -146,10 +148,9 @@ const _identifiableTaskPriorityMap = {
 @visibleForTesting
 extension IdentifiableTaskPriority on TaskPriority {
   /// The priority internal identifier.
-  String get identifier =>
-      _identifiableTaskPriorityMap.entries
-          .firstWhere((entry) => entry.value == this)
-          .key;
+  String get identifier => _identifiableTaskPriorityMap.entries
+      .firstWhere((entry) => entry.value == this)
+      .key;
 }
 
 /// An extension on a [String] that represents a [TaskPriority] identifier.

--- a/bricks/altoke_local_database/reference/local_database/hive_local_database/lib/src/local_tasks_dao.dart
+++ b/bricks/altoke_local_database/reference/local_database/hive_local_database/lib/src/local_tasks_dao.dart
@@ -22,10 +22,10 @@ class LocalTasksHiveDao implements LocalTasksDao {
   Future<Task> createOne(NewTask newTask) async {
     final NewTask(:title, :priority, :description) = newTask;
     final titleValidationErrors = {
-      if (title.trim().isEmpty) TaskTitleValidationError.empty,
+      if (title.isBlank) TaskTitleValidationError.empty,
     };
     final complexValidationErrors = {
-      if (priority == TaskPriority.high && (description ?? '').trim().isEmpty)
+      if (priority == TaskPriority.high && description.isBlank)
         TaskComplexValidationError.highPriorityWithNoDescription,
     };
     if (titleValidationErrors.isNotEmpty ||
@@ -39,9 +39,7 @@ class LocalTasksHiveDao implements LocalTasksDao {
     final id = await tasksBox.add({
       hive.Task.titleJsonKey: title,
       hive.Task.priorityJsonKey: priority.identifier,
-      hive.Task.descriptionJsonKey: ((description ?? '').trim().isEmpty)
-          ? null
-          : description?.trim(),
+      hive.Task.descriptionJsonKey: description.nonBlankOrNull,
       hive.Task.completedJsonKey: false,
     });
     return newTask.toTaskWithId(id);
@@ -73,14 +71,14 @@ class LocalTasksHiveDao implements LocalTasksDao {
     }
     final PartialTask(:title, :priority, :completed, :description) = task;
     final titleValidationErrors = {
-      if (title case Some(value: final title) when title.trim().isEmpty)
+      if (title case Some(value: final title) when title.isBlank)
         TaskTitleValidationError.empty,
     };
     final complexValidationErrors = {
       if (priority == const Some(TaskPriority.high))
         if (description case Some(
           value: final description,
-        ) when (description ?? '').trim().isEmpty)
+        ) when description.isBlank)
           TaskComplexValidationError.highPriorityWithNoDescription,
     };
     if (titleValidationErrors.isNotEmpty ||
@@ -100,9 +98,7 @@ class LocalTasksHiveDao implements LocalTasksDao {
       rawTask[hive.Task.completedJsonKey] = completed;
     }
     if (description case Some(value: final description)) {
-      rawTask[hive.Task.descriptionJsonKey] = (description ?? '').trim().isEmpty
-          ? null
-          : description?.trim();
+      rawTask[hive.Task.descriptionJsonKey] = description.nonBlankOrNull;
     }
     await tasksBox.put(taskId, rawTask);
   }
@@ -158,4 +154,16 @@ extension IdentifiableTaskPriority on TaskPriority {
 extension TaskPriorityIdentifier on String {
   /// Returns the corresponding [TaskPriority].
   TaskPriority toTaskPriority() => _identifiableTaskPriorityMap[this]!;
+}
+
+/// Extension methods for nullable strings.
+@visibleForTesting
+extension ExtendedNullableString on String? {
+  String get _trimmed => (this ?? '').trim();
+
+  /// Returns `true` if the string is `null` or empty.
+  bool get isBlank => _trimmed.isEmpty;
+
+  /// Returns the trimmed string if it is not empty, otherwise returns `null`.
+  String? get nonBlankOrNull => isBlank ? null : _trimmed;
 }

--- a/bricks/altoke_local_database/reference/local_database/hive_local_database/pubspec.yaml
+++ b/bricks/altoke_local_database/reference/local_database/hive_local_database/pubspec.yaml
@@ -8,7 +8,7 @@ resolution: workspace
 #w 2v w#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   #w 1v 2> w#

--- a/bricks/altoke_local_database/reference/local_database/hive_local_database/test/src/local_tasks_dao_test.dart
+++ b/bricks/altoke_local_database/reference/local_database/hive_local_database/test/src/local_tasks_dao_test.dart
@@ -64,12 +64,14 @@ THEN a task record is registered
               task[hive.Task.titleJsonKey] == newTask.title &&
               task[hive.Task.priorityJsonKey] == newTask.priority.identifier &&
               task[hive.Task.descriptionJsonKey] == null;
-          final existingMatchingTasksCount =
-              tasksBox.values.where(filter).length;
+          final existingMatchingTasksCount = tasksBox.values
+              .where(filter)
+              .length;
           expect(existingMatchingTasksCount, isZero);
           await dao.createOne(newTask);
-          final resultingMatchingTasksCount =
-              tasksBox.values.where(filter).length;
+          final resultingMatchingTasksCount = tasksBox.values
+              .where(filter)
+              .length;
           expect(resultingMatchingTasksCount, existingMatchingTasksCount + 1);
         },
       );
@@ -223,10 +225,9 @@ THEN the tasks are continuously emitted as they change
                   (entry) => entry.value[hive.Task.descriptionJsonKey] == null,
                 )
                 .map(
-                  (entry) =>
-                      entry
-                        ..value[hive.Task.descriptionJsonKey] =
-                            'updated description',
+                  (entry) => entry
+                    ..value[hive.Task.descriptionJsonKey] =
+                        'updated description',
                 );
             await tasksBox.putAll(Map.fromEntries(updatedTaskRecordEntries));
           }
@@ -267,8 +268,11 @@ THEN a task record is updated
                 data[hive.Task.descriptionJsonKey] == newDescription;
           }
 
-          final existingMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final existingMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(existingMatchingTasksCount, isZero);
           await dao.updateOneById(
             taskId: taskId,
@@ -279,8 +283,11 @@ THEN a task record is updated
               description: Some(newDescription),
             ),
           );
-          final resultingMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final resultingMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(resultingMatchingTasksCount, existingMatchingTasksCount + 1);
         },
       );
@@ -313,8 +320,11 @@ AND no task record is updated
                 data[hive.Task.descriptionJsonKey] == newDescription;
           }
 
-          final existingMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final existingMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(existingMatchingTasksCount, isZero);
           expect(
             () async => dao.updateOneById(
@@ -328,8 +338,11 @@ AND no task record is updated
             ),
             throwsA(isA<UpdateTaskFailureNotFound>()),
           );
-          final resultingMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final resultingMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(resultingMatchingTasksCount, isZero);
         },
       );
@@ -369,8 +382,11 @@ AND no task record is updated
                 data[hive.Task.descriptionJsonKey] == newDescription;
           }
 
-          final existingMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final existingMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(existingMatchingTasksCount, isZero);
           expect(
             () async => dao.updateOneById(
@@ -384,8 +400,11 @@ AND no task record is updated
             ),
             throwsA(isA<UpdateTaskFailureInvalidData>()),
           );
-          final resultingMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final resultingMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(resultingMatchingTasksCount, isZero);
         },
       );
@@ -410,12 +429,18 @@ AND the deleted task is returned
           await tasksBox.put(taskId, task);
           bool filter(MapEntry<dynamic, Map<dynamic, dynamic>> rawTask) =>
               rawTask.key == taskId;
-          final initialMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final initialMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(initialMatchingTasksCount, 1);
           await dao.deleteOneById(taskId);
-          final resultingMatchingTasksCount =
-              tasksBox.toMap().entries.where(filter).length;
+          final resultingMatchingTasksCount = tasksBox
+              .toMap()
+              .entries
+              .where(filter)
+              .length;
           expect(resultingMatchingTasksCount, isZero);
         },
       );

--- a/bricks/altoke_local_database/reference/local_database/isar_local_database/pubspec.yaml
+++ b/bricks/altoke_local_database/reference/local_database/isar_local_database/pubspec.yaml
@@ -8,7 +8,7 @@ resolution: workspace
 #w 2v w#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   #w 1v 2> w#

--- a/bricks/altoke_local_database/reference/local_database/local_database/pubspec.yaml
+++ b/bricks/altoke_local_database/reference/local_database/local_database/pubspec.yaml
@@ -8,7 +8,7 @@ resolution: workspace
 #w 2v w#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   #w 1v 2> w#

--- a/bricks/altoke_local_database/reference/local_database/sembast_local_database/lib/src/local_tasks_dao.dart
+++ b/bricks/altoke_local_database/reference/local_database/sembast_local_database/lib/src/local_tasks_dao.dart
@@ -27,10 +27,10 @@ class LocalTasksSembastDao implements LocalTasksDao {
   Future<Task> createOne(NewTask newTask) async {
     final NewTask(:title, :priority, :description) = newTask;
     final titleValidationErrors = {
-      if (title.trim().isEmpty) TaskTitleValidationError.empty,
+      if (title.isBlank) TaskTitleValidationError.empty,
     };
     final complexValidationErrors = {
-      if (priority == TaskPriority.high && (description ?? '').trim().isEmpty)
+      if (priority == TaskPriority.high && description.isBlank)
         TaskComplexValidationError.highPriorityWithNoDescription,
     };
     if (titleValidationErrors.isNotEmpty ||
@@ -44,9 +44,7 @@ class LocalTasksSembastDao implements LocalTasksDao {
     final id = await tasksStore.add(database, {
       sembast.Task.titleJsonKey: title,
       sembast.Task.priorityJsonKey: priority.identifier,
-      sembast.Task.descriptionJsonKey: ((description ?? '').trim().isEmpty)
-          ? null
-          : description?.trim(),
+      sembast.Task.descriptionJsonKey: description.nonBlankOrNull,
       sembast.Task.completedJsonKey: false,
     });
     return newTask.toTaskWithId(id);
@@ -71,14 +69,14 @@ class LocalTasksSembastDao implements LocalTasksDao {
     }
     final PartialTask(:title, :priority, :completed, :description) = task;
     final titleValidationErrors = {
-      if (title case Some(value: final title) when title.trim().isEmpty)
+      if (title case Some(value: final title) when title.isBlank)
         TaskTitleValidationError.empty,
     };
     final complexValidationErrors = {
       if (priority == const Some(TaskPriority.high))
         if (description case Some(
           value: final description,
-        ) when (description ?? '').trim().isEmpty)
+        ) when description.isBlank)
           TaskComplexValidationError.highPriorityWithNoDescription,
     };
     if (titleValidationErrors.isNotEmpty ||
@@ -99,8 +97,7 @@ class LocalTasksSembastDao implements LocalTasksDao {
       taskPatch[sembast.Task.completedJsonKey] = completed;
     }
     if (description case Some(value: final description)) {
-      taskPatch[sembast.Task.descriptionJsonKey] =
-          (description ?? '').trim().isEmpty ? null : description?.trim();
+      taskPatch[sembast.Task.descriptionJsonKey] = description.nonBlankOrNull;
     }
     await tasksStore.record(taskId).put(database, taskPatch, merge: true);
   }
@@ -156,4 +153,16 @@ extension IdentifiableTaskPriority on TaskPriority {
 extension TaskPriorityIdentifier on String {
   /// Returns the corresponding [TaskPriority].
   TaskPriority toTaskPriority() => _identifiableTaskPriorityMap[this]!;
+}
+
+/// Extension methods for nullable strings.
+@visibleForTesting
+extension ExtendedNullableString on String? {
+  String get _trimmed => (this ?? '').trim();
+
+  /// Returns `true` if the string is `null` or empty.
+  bool get isBlank => _trimmed.isEmpty;
+
+  /// Returns the trimmed string if it is not empty, otherwise returns `null`.
+  String? get nonBlankOrNull => isBlank ? null : _trimmed;
 }

--- a/bricks/altoke_local_database/reference/local_database/sembast_local_database/lib/src/local_tasks_dao.dart
+++ b/bricks/altoke_local_database/reference/local_database/sembast_local_database/lib/src/local_tasks_dao.dart
@@ -44,8 +44,9 @@ class LocalTasksSembastDao implements LocalTasksDao {
     final id = await tasksStore.add(database, {
       sembast.Task.titleJsonKey: title,
       sembast.Task.priorityJsonKey: priority.identifier,
-      sembast.Task.descriptionJsonKey:
-          ((description ?? '').trim().isEmpty) ? null : description?.trim(),
+      sembast.Task.descriptionJsonKey: ((description ?? '').trim().isEmpty)
+          ? null
+          : description?.trim(),
       sembast.Task.completedJsonKey: false,
     });
     return newTask.toTaskWithId(id);
@@ -126,8 +127,8 @@ extension on Iterable<RecordSnapshot<int, Map<String, Object?>>> {
     return Task(
       id: id,
       title: rawData[sembast.Task.titleJsonKey]! as String,
-      priority:
-          (rawData[sembast.Task.priorityJsonKey]! as String).toTaskPriority(),
+      priority: (rawData[sembast.Task.priorityJsonKey]! as String)
+          .toTaskPriority(),
       completed: rawData[sembast.Task.completedJsonKey]! as bool,
       description: rawData[sembast.Task.descriptionJsonKey] as String?,
     );
@@ -145,10 +146,9 @@ const _identifiableTaskPriorityMap = {
 @visibleForTesting
 extension IdentifiableTaskPriority on TaskPriority {
   /// The priority internal identifier.
-  String get identifier =>
-      _identifiableTaskPriorityMap.entries
-          .firstWhere((entry) => entry.value == this)
-          .key;
+  String get identifier => _identifiableTaskPriorityMap.entries
+      .firstWhere((entry) => entry.value == this)
+      .key;
 }
 
 /// An extension on a [String] that represents a [TaskPriority] identifier.

--- a/bricks/altoke_local_database/reference/local_database/sembast_local_database/pubspec.yaml
+++ b/bricks/altoke_local_database/reference/local_database/sembast_local_database/pubspec.yaml
@@ -8,7 +8,7 @@ resolution: workspace
 #w 2v w#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   #w 1v 2> w#

--- a/bricks/altoke_reactive_caches/brick/hooks/pubspec.yaml
+++ b/bricks/altoke_reactive_caches/brick/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/bricks/altoke_reactive_caches/e2e/pubspec.yaml
+++ b/bricks/altoke_reactive_caches/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   mason: ^0.1.1

--- a/bricks/altoke_reactive_caches/pubspec.yaml
+++ b/bricks/altoke_reactive_caches/pubspec.yaml
@@ -5,4 +5,4 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"

--- a/bricks/altoke_reactive_caches/reference/reactive_caches/pubspec.yaml
+++ b/bricks/altoke_reactive_caches/reference/reactive_caches/pubspec.yaml
@@ -8,7 +8,7 @@ resolution: workspace
 #w 2v w#
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   altoke_common:

--- a/bricks/altoke_reactive_caches/reference/reactive_caches/test/src/immediate_firer_stream_test.dart
+++ b/bricks/altoke_reactive_caches/reference/reactive_caches/test/src/immediate_firer_stream_test.dart
@@ -28,8 +28,8 @@ void main() {
     test('emits the latest value on each new subscription', () async {
       final values1 = <int>[];
       final stream = buildSubject(
-        computeInitialValue:
-            () => values1.isEmpty ? const None<int>() : Some<int>(values1.last),
+        computeInitialValue: () =>
+            values1.isEmpty ? const None<int>() : Some<int>(values1.last),
       );
       final sub1 = stream.listen(values1.add);
       addTearDown(sub1.cancel);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   auto_route:
     dependency: transitive
     description:
@@ -349,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -505,10 +505,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1094,10 +1094,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:
@@ -1179,5 +1179,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: altoke_bricks_monorepo
 repository: https://github.com/mrverdant13/altoke_bricks
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   melos: ^7.0.0-dev.8
@@ -25,10 +25,11 @@ melos:
   command:
     bootstrap:
       environment:
-        sdk: ">=3.7.0 <4.0.0"
-        flutter: ">=3.29.0 <4.0.0"
+        sdk: ">=3.8.0 <4.0.0"
+        flutter: ">=3.32.0 <4.0.0"
       dependencies:
         collection: ^1.19.1
+        intl: ^0.20.2
         mason: ^0.1.1
         meta: ^1.16.0
         path: ^1.9.1

--- a/tools/brick_generator/pubspec.yaml
+++ b/tools/brick_generator/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   dart_mappable: ^4.5.0

--- a/tools/brick_generator/test/src/reference_file_test.dart
+++ b/tools/brick_generator/test/src/reference_file_test.dart
@@ -262,7 +262,8 @@ line 5
             final file = testDir.descendantFile('file$index.txt');
             expect(file.existsSync(), isFalse);
             file.createSync(recursive: true);
-            final originalContent = '''
+            final originalContent =
+                '''
 line 0
 line 1
 line 2
@@ -515,7 +516,8 @@ and even more text
             final partialFile = testDir.descendantFile(
               'partial$partialName.partial',
             );
-            final partialContent = '''
+            final partialContent =
+                '''
 this is
 the partial
 $partialName

--- a/tools/data_persistence_approach/lib/src/data_persistence_approach.dart
+++ b/tools/data_persistence_approach/lib/src/data_persistence_approach.dart
@@ -16,11 +16,9 @@ enum DataPersistenceApproach {
   factory DataPersistenceApproach.fromVarIdentifier(String varIdentifier) {
     return DataPersistenceApproach.values.firstWhere(
       (approach) => approach.varIdentifier == varIdentifier,
-      orElse:
-          () =>
-              throw ArgumentError(
-                'Invalid data persistence approach: $varIdentifier',
-              ),
+      orElse: () => throw ArgumentError(
+        'Invalid data persistence approach: $varIdentifier',
+      ),
     );
   }
 

--- a/tools/data_persistence_approach/pubspec.yaml
+++ b/tools/data_persistence_approach/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/tools/local_brick_installer/pubspec.yaml
+++ b/tools/local_brick_installer/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   monorepo_elements:

--- a/tools/local_database_alternative/lib/src/local_database_alternative.dart
+++ b/tools/local_database_alternative/lib/src/local_database_alternative.dart
@@ -22,11 +22,9 @@ enum LocalDatabaseAlternative {
   factory LocalDatabaseAlternative.fromVarIdentifier(String varIdentifier) {
     return LocalDatabaseAlternative.values.firstWhere(
       (alternative) => alternative.varIdentifier == varIdentifier,
-      orElse:
-          () =>
-              throw ArgumentError(
-                'Invalid local database alternative: $varIdentifier',
-              ),
+      orElse: () => throw ArgumentError(
+        'Invalid local database alternative: $varIdentifier',
+      ),
     );
   }
 

--- a/tools/local_database_alternative/pubspec.yaml
+++ b/tools/local_database_alternative/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/tools/monorepo_elements/pubspec.yaml
+++ b/tools/monorepo_elements/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/tools/pubspec_deps_sorter/pubspec.yaml
+++ b/tools/pubspec_deps_sorter/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   path: ^1.9.1

--- a/tools/readmes_resolver/lib/reset_root_readme.dart
+++ b/tools/readmes_resolver/lib/reset_root_readme.dart
@@ -9,8 +9,10 @@ Future<void> main(List<String> args) async {
     '$featuresToken(.*?)$featuresToken',
     dotAll: true,
   );
-  final rootFeatures =
-      featuresRegex.firstMatch(rootReadmeContent)?.group(1)?.trim();
+  final rootFeatures = featuresRegex
+      .firstMatch(rootReadmeContent)
+      ?.group(1)
+      ?.trim();
   if (rootFeatures == null) {
     throw StateError('Features not found in brick readme');
   }
@@ -20,8 +22,10 @@ Future<void> main(List<String> args) async {
     '$bricksLinksToken(.*?)$bricksLinksToken',
     dotAll: true,
   );
-  final rootBricksLinks =
-      bricksLinksRegex.firstMatch(rootReadmeContent)?.group(1)?.trim();
+  final rootBricksLinks = bricksLinksRegex
+      .firstMatch(rootReadmeContent)
+      ?.group(1)
+      ?.trim();
   if (rootBricksLinks == null) {
     throw StateError('Bricks links not found in root readme');
   }

--- a/tools/readmes_resolver/lib/resolve_brick_readme.dart
+++ b/tools/readmes_resolver/lib/resolve_brick_readme.dart
@@ -15,8 +15,10 @@ void main(List<String> args) {
     '$bannersHeaderToken(.*?)$bannersHeaderToken',
     dotAll: true,
   );
-  final rootBannersHeader =
-      bannersHeaderRegex.firstMatch(initialRootReadmeContent)?.group(1)?.trim();
+  final rootBannersHeader = bannersHeaderRegex
+      .firstMatch(initialRootReadmeContent)
+      ?.group(1)
+      ?.trim();
   if (rootBannersHeader == null) {
     throw StateError('Banners header not found in root readme');
   }
@@ -59,19 +61,17 @@ void main(List<String> args) {
 
   final resolvedBrickReadme = initialBrickReadmeContent
       .replaceAllMapped(bannersHeaderRegex, (match) {
-        final buf =
-            StringBuffer()
-              ..writeln(bannersHeaderToken)
-              ..writeln(rootBannersHeader)
-              ..writeln(bannersHeaderToken);
+        final buf = StringBuffer()
+          ..writeln(bannersHeaderToken)
+          ..writeln(rootBannersHeader)
+          ..writeln(bannersHeaderToken);
         return buf.toString().trim();
       })
       .replaceAllMapped(variablesRegex, (match) {
-        final buf =
-            StringBuffer()
-              ..writeln(variablesToken)
-              ..writeln(varsBuf.toString().trim())
-              ..writeln(variablesToken);
+        final buf = StringBuffer()
+          ..writeln(variablesToken)
+          ..writeln(varsBuf.toString().trim())
+          ..writeln(variablesToken);
         return buf.toString().trim();
       });
   brickReadmeFile.writeAsStringSync(resolvedBrickReadme);

--- a/tools/readmes_resolver/lib/resolve_root_readme.dart
+++ b/tools/readmes_resolver/lib/resolve_root_readme.dart
@@ -14,8 +14,10 @@ void main(List<String> args) {
     dotAll: true,
   );
   final headlineRegex = RegExp(r'^#+\s', multiLine: true);
-  final brickFeatures =
-      featuresRegex.firstMatch(initialBrickReadmeContent)?.group(1)?.trim();
+  final brickFeatures = featuresRegex
+      .firstMatch(initialBrickReadmeContent)
+      ?.group(1)
+      ?.trim();
   if (brickFeatures == null) {
     throw StateError('Features not found in brick readme');
   }
@@ -25,13 +27,17 @@ void main(List<String> args) {
     '$bricksLinksToken(.*?)$bricksLinksToken',
     dotAll: true,
   );
-  final rawRootBricksLinks =
-      bricksLinksRegex.firstMatch(initialRootReadmeContent)?.group(1)?.trim();
+  final rawRootBricksLinks = bricksLinksRegex
+      .firstMatch(initialRootReadmeContent)
+      ?.group(1)
+      ?.trim();
   if (rawRootBricksLinks == null) {
     throw StateError('Bricks links not found in root readme');
   }
-  final rawBricksLinks =
-      bricksLinksRegex.firstMatch(initialBrickReadmeContent)?.group(1)?.trim();
+  final rawBricksLinks = bricksLinksRegex
+      .firstMatch(initialBrickReadmeContent)
+      ?.group(1)
+      ?.trim();
   if (rawBricksLinks == null) {
     throw StateError('Bricks links not found in brick readme');
   }

--- a/tools/readmes_resolver/pubspec.yaml
+++ b/tools/readmes_resolver/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   checked_yaml: ^2.0.3

--- a/tools/router_package/lib/src/router_package.dart
+++ b/tools/router_package/lib/src/router_package.dart
@@ -13,9 +13,8 @@ enum RouterPackage {
   factory RouterPackage.fromReadableName(String readableName) {
     return RouterPackage.values.firstWhere(
       (package) => package.readableName == readableName,
-      orElse:
-          () =>
-              throw ArgumentError('Invalid router package name: $readableName'),
+      orElse: () =>
+          throw ArgumentError('Invalid router package name: $readableName'),
     );
   }
 

--- a/tools/router_package/pubspec.yaml
+++ b/tools/router_package/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1

--- a/tools/shell/lib/shell.dart
+++ b/tools/shell/lib/shell.dart
@@ -93,21 +93,20 @@ abstract class Shell {
     await onStart?.call();
     try {
       final outBuf = StringBuffer()..writeln();
-      final [int exitCode, ...] =
-          await [
-            process.exitCode,
-            process.stdout.forEach((raw) {
-              final record = String.fromCharCodes(raw);
-              outBuf.write('\x1B[34m$record\x1B[0m');
-            }),
-            process.stderr.forEach((raw) {
-              final record = String.fromCharCodes(raw);
-              outBuf.write('\x1B[31m$record\x1B[0m');
-            }),
-            if (stdin != null) process.stdin.addStream(stdin),
-            if (stdout != null) stdout.addStream(process.stdout),
-            if (stderr != null) stderr.addStream(process.stderr),
-          ].wait;
+      final [int exitCode, ...] = await [
+        process.exitCode,
+        process.stdout.forEach((raw) {
+          final record = String.fromCharCodes(raw);
+          outBuf.write('\x1B[34m$record\x1B[0m');
+        }),
+        process.stderr.forEach((raw) {
+          final record = String.fromCharCodes(raw);
+          outBuf.write('\x1B[31m$record\x1B[0m');
+        }),
+        if (stdin != null) process.stdin.addStream(stdin),
+        if (stdout != null) stdout.addStream(process.stdout),
+        if (stderr != null) stderr.addStream(process.stderr),
+      ].wait;
       if (exitCode != 0) {
         throw ProcessException(
           '\x1B[31m$executable\x1B[0m',

--- a/tools/shell/pubspec.yaml
+++ b/tools/shell/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dev_dependencies:
   very_good_analysis: ^7.0.0

--- a/tools/value_equality_approach/lib/src/value_equality_approach.dart
+++ b/tools/value_equality_approach/lib/src/value_equality_approach.dart
@@ -22,11 +22,8 @@ enum ValueEqualityApproach {
   factory ValueEqualityApproach.fromReadableName(String readableName) {
     return ValueEqualityApproach.values.firstWhere(
       (approach) => approach.readableName == readableName,
-      orElse:
-          () =>
-              throw ArgumentError(
-                'Invalid value equality approach: $readableName',
-              ),
+      orElse: () =>
+          throw ArgumentError('Invalid value equality approach: $readableName'),
     );
   }
 

--- a/tools/value_equality_approach/pubspec.yaml
+++ b/tools/value_equality_approach/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   mason: ^0.1.1


### PR DESCRIPTION
This pull request includes updates to workflows, SDK versions, and several code style improvements across multiple files. The most significant changes involve upgrading dependencies, improving code formatting, and ensuring consistency in generated files.

### Workflow Updates:

* [`.github/workflows/*`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL34-R34): Updated Flutter version from `3.29.0` to `3.32.0` in all CI workflows, including `ci.yaml`, `e2e.yaml`, `generate_templates.yaml`, and `resolve_readmes.yaml`. This ensures compatibility with the latest Flutter features. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL34-R34) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL74-R74) [[3]](diffhunk://#diff-a2de7550554c0198ac7f959c78a19ee0996921c98034411de47a7dd49b0c209bL32-R32) [[4]](diffhunk://#diff-5411e02a6353fc49d9ba62787ac078b8e4a2ceb48eddfd548e46e8bb3778d3eeL26-R26) [[5]](diffhunk://#diff-5411e02a6353fc49d9ba62787ac078b8e4a2ceb48eddfd548e46e8bb3778d3eeL58-R58) [[6]](diffhunk://#diff-23df0a3695f04334520477160be1b4310dc56938d2560d7a8672573546cf3417L25-R25) [[7]](diffhunk://#diff-23df0a3695f04334520477160be1b4310dc56938d2560d7a8672573546cf3417L61-R61) [[8]](diffhunk://#diff-23df0a3695f04334520477160be1b4310dc56938d2560d7a8672573546cf3417L93-R93)

### SDK Version Upgrades:

* `pubspec.yaml` files in `bricks/altoke_app`: Updated Dart SDK constraints from `>=3.7.0 <4.0.0` to `>=3.8.0 <4.0.0` to align with the latest Dart features. [[1]](diffhunk://#diff-36942cb69c1101b75d5e3773bcf83a7cf289970853451da13f28b87510ebf7a1L6-R6) [[2]](diffhunk://#diff-5b1752e4c0a05a4fb25bdcd6002ab17fd5dc398145d121d76fcbd9c3fae0a909L6-R6) [[3]](diffhunk://#diff-3a1571dd9ae9f01f38574d5c973867c6cdf15488beb4fad7db520952f21b3d6bL8-R8)

### Code Style and Formatting Improvements:

* [`bricks/altoke_app/e2e/brick_e2e_test.dart`](diffhunk://#diff-dea7270bd8d31cd6ffc6d017812dde1432a0c642cc1056a2d9ef3527909021ceL83-R84): Adjusted string formatting for better readability in `testSuccessfulGeneration` and `testGenerationWithoutHooks` methods. [[1]](diffhunk://#diff-dea7270bd8d31cd6ffc6d017812dde1432a0c642cc1056a2d9ef3527909021ceL83-R84) [[2]](diffhunk://#diff-dea7270bd8d31cd6ffc6d017812dde1432a0c642cc1056a2d9ef3527909021ceL154-R156)
* Various `.g.dart` files: Reformatted `debugGetCreateSourceHash` assignments for consistency across generated provider files. [[1]](diffhunk://#diff-32fd9bc1fc84d52c67fe090fd2cd36530b24b795c3ddaf123c2d5b77f8e9d831L17-R17) [[2]](diffhunk://#diff-f0df3f7219b73a90066dd448facda1a9e89bb7d32b98571c033af64a208958c5L16-R18) [[3]](diffhunk://#diff-95813aa5c07fe8d34ca0ea5b9068217fde2d2d585e0adbb2cb30952d059990d8L18-R18) [[4]](diffhunk://#diff-95813aa5c07fe8d34ca0ea5b9068217fde2d2d585e0adbb2cb30952d059990d8L46-R45) [[5]](diffhunk://#diff-95813aa5c07fe8d34ca0ea5b9068217fde2d2d585e0adbb2cb30952d059990d8L65-R70) [[6]](diffhunk://#diff-5f234b0906ddf908381609be58be6c06c618fd435517da289f6980171b195f82L18-R18) [[7]](diffhunk://#diff-5f234b0906ddf908381609be58be6c06c618fd435517da289f6980171b195f82L39-R38) [[8]](diffhunk://#diff-ac81008c30ca8d2af5ed37cbd06efed8709feb57795dacd655bf19e3c25e0e64L90-R90) [[9]](diffhunk://#diff-ac81008c30ca8d2af5ed37cbd06efed8709feb57795dacd655bf19e3c25e0e64L109-R108) [[10]](diffhunk://#diff-ac81008c30ca8d2af5ed37cbd06efed8709feb57795dacd655bf19e3c25e0e64L128-R128) [[11]](diffhunk://#diff-ac81008c30ca8d2af5ed37cbd06efed8709feb57795dacd655bf19e3c25e0e64L157-R156) [[12]](diffhunk://#diff-adec066c2be453e4ba700fd9dfb38f52fbd58a8dc5f8f9edc0ee7df9fada0181L16-R16)

### UI and Logic Adjustments:

* `RouterPackageSwitcherWrapper` in `app.dart`: Reformatted logic for readability when toggling router packages.
* `TaskListTile` in `task_list_tile.dart`: Improved readability of conditional styles for task completion.

### Other Changes:

* Removed `synthetic-package` property in `l10n.yaml` for localization configuration.
* Adjusted string trimming in `provider_observer.dart` for better logging formatting. [[1]](diffhunk://#diff-5fe65575e3733182bf0aff0a265837a8300f50bd15f631bea0f32302d3ead47fL36-R37) [[2]](diffhunk://#diff-5fe65575e3733182bf0aff0a265837a8300f50bd15f631bea0f32302d3ead47fL52-R54) [[3]](diffhunk://#diff-5fe65575e3733182bf0aff0a265837a8300f50bd15f631bea0f32302d3ead47fL74-R77) [[4]](diffhunk://#diff-5fe65575e3733182bf0aff0a265837a8300f50bd15f631bea0f32302d3ead47fL87-R91)