### PR TITLE
ci: explicit initial empty labels for dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,9 @@ updates:
     directory: /
     schedule:
       interval: daily
+    labels: []
   - package-ecosystem: pub
     directory: /
     schedule:
       interval: daily
+    labels: []


### PR DESCRIPTION
## Description

Explicit empty labels for dependabot PRs.
